### PR TITLE
claude/add-cases-paywall-stripe-NCpIY

### DIFF
--- a/content/courses/ai-agency-ops-bootcamp/module-1-ai-foundations-for-agencies/lesson-1-ai-landscape-for-agencies.md
+++ b/content/courses/ai-agency-ops-bootcamp/module-1-ai-foundations-for-agencies/lesson-1-ai-landscape-for-agencies.md
@@ -3,6 +3,7 @@ title: The AI Landscape for Agencies
 module: 1
 order: 1
 duration: 15
+preview: true
 ---
 
 # The AI Landscape for Agencies

--- a/content/courses/ai-for-agent-retention/module-1-foundation/lesson-1-why-retention-matters.md
+++ b/content/courses/ai-for-agent-retention/module-1-foundation/lesson-1-why-retention-matters.md
@@ -3,6 +3,7 @@ title: Why Retention Is the New Growth Lever
 module: 1
 order: 1
 duration: 14
+preview: true
 ---
 
 # Why Retention Is the New Growth Lever

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -69,6 +69,22 @@ model PasswordResetToken {
   createdAt DateTime @default(now())
 }
 
+// Captures email sign-ups from the public Mastermind / community waitlist
+// form. These are leads to contact directly — they haven't paid yet and are
+// not linked to an Organization until/unless they convert via Stripe.
+model MastermindInvite {
+  id        String    @id @default(cuid())
+  email     String    @unique
+  name      String?
+  source    String    @default("mastermind_page")
+  notes     String?
+  contacted Boolean   @default(false)
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
+
+  @@index([createdAt])
+}
+
 model AuditLog {
   id             String   @id @default(cuid())
   organizationId String?

--- a/src/app/(marketing)/courses/[courseSlug]/[moduleSlug]/[lessonSlug]/page.tsx
+++ b/src/app/(marketing)/courses/[courseSlug]/[moduleSlug]/[lessonSlug]/page.tsx
@@ -5,29 +5,20 @@ import { Header } from "@/components/marketing/Header";
 import { Footer } from "@/components/marketing/Footer";
 import { BookingProvider } from "@/components/marketing/BookingContext";
 import { LessonBody } from "@/components/courses/LessonBody";
-import { getLesson, listCourses } from "@/lib/courses";
+import { LessonPaywall } from "@/components/courses/LessonPaywall";
+import { getLesson } from "@/lib/courses";
+import { getCourseAccess } from "@/lib/entitlements";
+
+// The lesson page depends on the signed-in session for paywall checks, so
+// it can't be prerendered. Force dynamic rendering so access checks run on
+// every request.
+export const dynamic = "force-dynamic";
 
 type Params = {
   courseSlug: string;
   moduleSlug: string;
   lessonSlug: string;
 };
-
-export function generateStaticParams() {
-  const params: Params[] = [];
-  for (const course of listCourses()) {
-    for (const mod of course.modules) {
-      for (const lesson of mod.lessons) {
-        params.push({
-          courseSlug: course.slug,
-          moduleSlug: mod.moduleSlug,
-          lessonSlug: lesson.lessonSlug,
-        });
-      }
-    }
-  }
-  return params;
-}
 
 export async function generateMetadata({
   params,
@@ -57,12 +48,17 @@ export default async function LessonPage({
 
   const { course, module: mod, lesson } = result;
 
+  // Gate everything that isn't explicitly marked as a free teaser.
+  const access = lesson.preview ? null : await getCourseAccess();
+  const locked = access !== null && !access.allowed;
+
   // Build flat lesson list for prev/next navigation across the whole course.
   const flat = course.modules.flatMap((m) =>
     m.lessons.map((l) => ({
       moduleSlug: m.moduleSlug,
       lessonSlug: l.lessonSlug,
       title: l.title,
+      preview: Boolean(l.preview),
     }))
   );
   const idx = flat.findIndex(
@@ -87,15 +83,36 @@ export default async function LessonPage({
             <div className="mb-10">
               <p className="text-sm text-neutral-500 font-semibold uppercase tracking-wider mb-3">
                 Module {mod.number} · {mod.title} · {lesson.duration} min read
+                {lesson.preview && (
+                  <span className="ml-3 inline-block bg-blue-600/20 text-blue-400 text-[10px] font-bold uppercase tracking-wider px-2 py-1 rounded-full align-middle">
+                    Free preview
+                  </span>
+                )}
               </p>
               <h1 className="text-4xl md:text-5xl font-black mb-4">
                 {lesson.title}
               </h1>
             </div>
 
-            <article>
-              <LessonBody body={lesson.body} />
-            </article>
+            {locked && access && !access.allowed ? (
+              <LessonPaywall
+                courseTitle={course.title}
+                coursePrice={course.price}
+                courseHref={`/courses/${course.slug}`}
+                returnHref={`/courses/${course.slug}/${mod.moduleSlug}/${lesson.lessonSlug}`}
+                reason={
+                  access.reason === "unauthenticated"
+                    ? "unauthenticated"
+                    : access.reason === "no_organization"
+                      ? "no_organization"
+                      : "inactive_subscription"
+                }
+              />
+            ) : (
+              <article>
+                <LessonBody body={lesson.body} />
+              </article>
+            )}
 
             <div className="mt-16 pt-8 border-t border-neutral-800 flex flex-col sm:flex-row gap-4 justify-between">
               {prev ? (

--- a/src/app/(marketing)/courses/[courseSlug]/page.tsx
+++ b/src/app/(marketing)/courses/[courseSlug]/page.tsx
@@ -118,12 +118,22 @@ export default async function CourseLandingPage({
                         <li key={l.lessonSlug}>
                           <Link
                             href={`/courses/${course.slug}/${m.moduleSlug}/${l.lessonSlug}`}
-                            className="flex items-center justify-between text-neutral-300 hover:text-white py-2 border-b border-neutral-800"
+                            className="flex items-center justify-between text-neutral-300 hover:text-white py-2 border-b border-neutral-800 gap-4"
                           >
-                            <span className="font-semibold">
-                              {l.order}. {l.title}
+                            <span className="font-semibold flex items-center gap-2 min-w-0">
+                              <span className="flex-shrink-0" aria-hidden="true">
+                                {l.preview ? "🔓" : "🔒"}
+                              </span>
+                              <span className="truncate">
+                                {l.order}. {l.title}
+                              </span>
+                              {l.preview && (
+                                <span className="flex-shrink-0 bg-blue-600/20 text-blue-400 text-[10px] font-bold uppercase tracking-wider px-2 py-0.5 rounded-full">
+                                  Free
+                                </span>
+                              )}
                             </span>
-                            <span className="text-sm text-neutral-500">
+                            <span className="text-sm text-neutral-500 flex-shrink-0">
                               {l.duration} min
                             </span>
                           </Link>

--- a/src/app/(marketing)/mastermind/page.tsx
+++ b/src/app/(marketing)/mastermind/page.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from "next";
 import { Header } from "@/components/marketing/Header";
 import { Footer } from "@/components/marketing/Footer";
 import { BookingProvider } from "@/components/marketing/BookingContext";
-import { BookAuditButton } from "@/components/courses/BookAuditButton";
+import { MastermindInviteForm } from "@/components/marketing/MastermindInviteForm";
 
 export const metadata: Metadata = {
   title: "AI Mastermind & Community | RenewalEngineAI",
@@ -85,10 +85,7 @@ export default function MastermindPage() {
                 same work. Not for passive consumption — mastermind members show
                 up.
               </p>
-              <BookAuditButton
-                label="Request an invite"
-                className="inline-block bg-blue-600 hover:bg-blue-700 text-white font-bold rounded-full px-8 py-4 transition-colors"
-              />
+              <MastermindInviteForm />
             </div>
           </div>
         </main>

--- a/src/app/api/mastermind/invite/route.ts
+++ b/src/app/api/mastermind/invite/route.ts
@@ -1,0 +1,69 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/db";
+import { sendMastermindInviteNotification } from "@/lib/email";
+import { logAudit } from "@/lib/audit";
+import { log } from "@/lib/logger";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// Basic RFC 5322-lite email check. Good enough to reject obvious junk; the
+// source of truth is the `email` column's uniqueness constraint.
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = (await req.json().catch(() => ({}))) as {
+      email?: unknown;
+      name?: unknown;
+      source?: unknown;
+      notes?: unknown;
+    };
+
+    const email =
+      typeof body.email === "string" ? body.email.trim().toLowerCase() : "";
+    const name =
+      typeof body.name === "string" && body.name.trim() ? body.name.trim() : null;
+    const source =
+      typeof body.source === "string" && body.source.trim()
+        ? body.source.trim().slice(0, 64)
+        : "mastermind_page";
+    const notes =
+      typeof body.notes === "string" && body.notes.trim()
+        ? body.notes.trim().slice(0, 2000)
+        : null;
+
+    if (!email || !EMAIL_RE.test(email) || email.length > 254) {
+      return NextResponse.json({ error: "invalid_email" }, { status: 400 });
+    }
+
+    // Upsert so duplicate submissions return success without creating
+    // duplicate rows. Existing rows keep their `contacted` flag.
+    const invite = await prisma.mastermindInvite.upsert({
+      where: { email },
+      create: { email, name, source, notes },
+      update: {
+        name: name ?? undefined,
+        notes: notes ?? undefined,
+      },
+    });
+
+    await logAudit({
+      action: "mastermind_invite.submitted",
+      resource: "MastermindInvite",
+      resourceId: invite.id,
+      metadata: { source },
+    });
+
+    // Fire-and-forget notification to the ops inbox. Do not block the
+    // response on email delivery — the DB row is the source of truth.
+    sendMastermindInviteNotification(email, name, source).catch((err) => {
+      log.error("[mastermind-invite] notification failed:", err);
+    });
+
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    log.error("[mastermind-invite] submission failed:", err);
+    return NextResponse.json({ error: "submission_failed" }, { status: 500 });
+  }
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -29,7 +29,19 @@ export default function LoginPage() {
       setError("Invalid email or password");
       setLoading(false);
     } else {
-      router.push("/dashboard");
+      // Honor ?callbackUrl=... so users returning from a paywalled lesson
+      // land back on the page they were trying to read. Accept only
+      // same-origin relative paths to avoid open redirects.
+      let next = "/dashboard";
+      if (typeof window !== "undefined") {
+        const raw = new URLSearchParams(window.location.search).get(
+          "callbackUrl"
+        );
+        if (raw && raw.startsWith("/") && !raw.startsWith("//")) {
+          next = raw;
+        }
+      }
+      router.push(next);
     }
   };
 

--- a/src/components/courses/LessonPaywall.tsx
+++ b/src/components/courses/LessonPaywall.tsx
@@ -1,0 +1,74 @@
+import Link from "next/link";
+import { formatPrice } from "@/lib/courses";
+
+type Props = {
+  courseTitle: string;
+  coursePrice: number;
+  courseHref: string;
+  returnHref: string;
+  reason:
+    | "unauthenticated"
+    | "no_organization"
+    | "inactive_subscription";
+};
+
+export function LessonPaywall({
+  courseTitle,
+  coursePrice,
+  courseHref,
+  returnHref,
+  reason,
+}: Props) {
+  const isLoggedOut = reason === "unauthenticated";
+
+  const loginHref = `/login?callbackUrl=${encodeURIComponent(returnHref)}`;
+
+  return (
+    <div className="bg-gradient-to-b from-neutral-900 to-black border border-neutral-800 rounded-2xl p-8 md:p-12 my-10">
+      <p className="text-blue-500 font-bold uppercase tracking-wider text-xs mb-3">
+        Members-only lesson
+      </p>
+      <h2 className="text-3xl md:text-4xl font-black mb-4">
+        This lesson is part of {courseTitle}
+      </h2>
+      <p className="text-neutral-300 text-lg mb-6 max-w-2xl">
+        {isLoggedOut
+          ? "Sign in with the account you used to enroll, or grab the course below to unlock every lesson, template, and prompt."
+          : reason === "inactive_subscription"
+            ? "Your subscription isn't active right now. Reactivate it to pick up where you left off."
+            : "We couldn't find an active subscription on your account. Enroll below to unlock every lesson, template, and prompt."}
+      </p>
+
+      <div className="flex flex-wrap items-center gap-4 mb-8">
+        <span className="text-3xl font-black text-white">
+          {formatPrice(coursePrice)}
+        </span>
+        <span className="text-neutral-500 text-sm">
+          One-time · lifetime access · 30-day guarantee
+        </span>
+      </div>
+
+      <div className="flex flex-wrap gap-3">
+        <Link
+          href={courseHref}
+          className="inline-block bg-blue-600 hover:bg-blue-700 text-white font-bold rounded-full px-8 py-4 transition-colors"
+        >
+          Enroll in {courseTitle}
+        </Link>
+        {isLoggedOut && (
+          <Link
+            href={loginHref}
+            className="inline-block border border-neutral-700 hover:border-neutral-500 text-white font-semibold rounded-full px-8 py-4 transition-colors"
+          >
+            I already have an account
+          </Link>
+        )}
+      </div>
+
+      <p className="text-neutral-500 text-xs mt-6">
+        The first lesson of module 1 is free so you can get a feel for the
+        material before you buy.
+      </p>
+    </div>
+  );
+}

--- a/src/components/marketing/MastermindInviteForm.tsx
+++ b/src/components/marketing/MastermindInviteForm.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+
+type Status = "idle" | "submitting" | "success" | "error";
+
+export function MastermindInviteForm() {
+  const [email, setEmail] = useState("");
+  const [name, setName] = useState("");
+  const [status, setStatus] = useState<Status>("idle");
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    if (status === "submitting") return;
+
+    const trimmedEmail = email.trim();
+    if (!trimmedEmail) {
+      setError("Please enter your email.");
+      setStatus("error");
+      return;
+    }
+
+    setStatus("submitting");
+    setError(null);
+
+    try {
+      const res = await fetch("/api/mastermind/invite", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          email: trimmedEmail,
+          name: name.trim() || undefined,
+          source: "mastermind_page",
+        }),
+      });
+
+      if (!res.ok) {
+        const data = (await res.json().catch(() => ({}))) as { error?: string };
+        setError(
+          data.error === "invalid_email"
+            ? "That email doesn't look right — please double-check it."
+            : "Something went wrong. Please try again in a moment."
+        );
+        setStatus("error");
+        return;
+      }
+
+      setStatus("success");
+      setEmail("");
+      setName("");
+    } catch {
+      setError("Something went wrong. Please try again in a moment.");
+      setStatus("error");
+    }
+  }
+
+  if (status === "success") {
+    return (
+      <div className="bg-blue-600/10 border border-blue-600/40 rounded-2xl p-6 text-center">
+        <p className="text-white font-bold text-lg mb-1">You&apos;re on the list.</p>
+        <p className="text-neutral-300 text-sm">
+          We&apos;ll be in touch within a day or two with invite details and
+          next steps.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="flex flex-col gap-3 max-w-md mx-auto text-left"
+    >
+      <div>
+        <label
+          htmlFor="mastermind-name"
+          className="block text-xs uppercase tracking-wider text-neutral-500 font-semibold mb-2"
+        >
+          Name <span className="text-neutral-600">(optional)</span>
+        </label>
+        <input
+          id="mastermind-name"
+          type="text"
+          autoComplete="name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="w-full bg-black border border-neutral-700 rounded-xl px-4 py-3 text-white placeholder-neutral-600 focus:outline-none focus:border-blue-500"
+          placeholder="Alex Johnson"
+        />
+      </div>
+      <div>
+        <label
+          htmlFor="mastermind-email"
+          className="block text-xs uppercase tracking-wider text-neutral-500 font-semibold mb-2"
+        >
+          Work email
+        </label>
+        <input
+          id="mastermind-email"
+          type="email"
+          autoComplete="email"
+          required
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          className="w-full bg-black border border-neutral-700 rounded-xl px-4 py-3 text-white placeholder-neutral-600 focus:outline-none focus:border-blue-500"
+          placeholder="you@agency.com"
+        />
+      </div>
+      <button
+        type="submit"
+        disabled={status === "submitting"}
+        className="bg-blue-600 hover:bg-blue-700 disabled:bg-blue-800 disabled:cursor-not-allowed text-white font-bold rounded-full px-8 py-4 transition-colors"
+      >
+        {status === "submitting" ? "Sending…" : "Request an invite"}
+      </button>
+      {error && (
+        <p className="text-sm text-red-400" role="alert">
+          {error}
+        </p>
+      )}
+      <p className="text-xs text-neutral-500 text-center">
+        No spam. We&apos;ll only email you about Mastermind onboarding.
+      </p>
+    </form>
+  );
+}

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -21,7 +21,8 @@ export type AuditAction =
   | "user.login"
   | "user.password_reset"
   | "data.exported"
-  | "data.deleted";
+  | "data.deleted"
+  | "mastermind_invite.submitted";
 
 export async function logAudit(params: {
   organizationId?: string;

--- a/src/lib/courses.ts
+++ b/src/lib/courses.ts
@@ -15,6 +15,9 @@ export type LessonFrontmatter = {
   module: number;
   order: number;
   duration: number;
+  // When true, this lesson is publicly readable without a paid subscription.
+  // Used to expose a teaser lesson at the top of module 1.
+  preview?: boolean;
 };
 
 export type Lesson = LessonFrontmatter & {
@@ -79,6 +82,7 @@ function loadCourse(courseDirName: string): Course | undefined {
       );
       return {
         ...l,
+        preview: l.preview === true,
         courseSlug: attributes.slug,
         moduleSlug,
         lessonSlug: fileName.replace(/\.md$/, ""),

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -121,6 +121,44 @@ export async function sendAutomationAlert(
   });
 }
 
+export async function sendMastermindInviteNotification(
+  email: string,
+  name: string | null,
+  source: string
+): Promise<void> {
+  const to = process.env.MASTERMIND_INVITES_TO || "josh@renewalengineai.com";
+
+  await sendEmail({
+    to,
+    subject: `New Mastermind invite request — ${email}`,
+    html: `
+      <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 600px; margin: 0 auto; padding: 40px 20px;">
+        <h2 style="color: #0a0a0a; font-size: 20px;">New Mastermind invite request</h2>
+        <p style="color: #525252; font-size: 16px; line-height: 1.6;">
+          A new prospect just asked to be invited to the AI Mastermind &amp; Community.
+        </p>
+        <table style="width: 100%; border-collapse: collapse; margin: 24px 0; font-size: 15px;">
+          <tr>
+            <td style="padding: 8px 0; color: #737373;">Email</td>
+            <td style="padding: 8px 0; color: #0a0a0a; font-weight: 600;">${email}</td>
+          </tr>
+          <tr>
+            <td style="padding: 8px 0; color: #737373;">Name</td>
+            <td style="padding: 8px 0; color: #0a0a0a; font-weight: 600;">${name || "—"}</td>
+          </tr>
+          <tr>
+            <td style="padding: 8px 0; color: #737373;">Source</td>
+            <td style="padding: 8px 0; color: #0a0a0a; font-weight: 600;">${source}</td>
+          </tr>
+        </table>
+        <p style="color: #a3a3a3; font-size: 13px;">
+          Reach out within 24 hours. The full list lives in the MastermindInvite table.
+        </p>
+      </div>
+    `,
+  });
+}
+
 export async function sendTokenExpiryWarning(
   email: string,
   provider: string

--- a/src/lib/entitlements.ts
+++ b/src/lib/entitlements.ts
@@ -1,0 +1,52 @@
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/db";
+import type { SubscriptionStatus, SubscriptionTier } from "@prisma/client";
+
+export type CourseAccess =
+  | { allowed: true; reason: "active_subscription"; tier: SubscriptionTier }
+  | { allowed: false; reason: "unauthenticated" }
+  | { allowed: false; reason: "no_organization" }
+  | { allowed: false; reason: "inactive_subscription"; status: SubscriptionStatus };
+
+// A user has access to paid course content if they are signed in and their
+// organization has a subscription in a state that should grant access.
+// We intentionally treat ACTIVE and TRIALING as entitled. CANCELED and
+// PAST_DUE are not. Any paid tier (AUDIT / SPRINT / MANAGED) currently
+// includes the course library — if that changes, narrow the check here.
+const ENTITLED_STATUSES: SubscriptionStatus[] = ["ACTIVE", "TRIALING"];
+
+export async function getCourseAccess(): Promise<CourseAccess> {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return { allowed: false, reason: "unauthenticated" };
+  }
+
+  const organizationId = (session as unknown as { organizationId?: string })
+    .organizationId;
+  if (!organizationId) {
+    return { allowed: false, reason: "no_organization" };
+  }
+
+  const org = await prisma.organization.findUnique({
+    where: { id: organizationId },
+    select: { subscriptionTier: true, subscriptionStatus: true },
+  });
+
+  if (!org) {
+    return { allowed: false, reason: "no_organization" };
+  }
+
+  if (!ENTITLED_STATUSES.includes(org.subscriptionStatus)) {
+    return {
+      allowed: false,
+      reason: "inactive_subscription",
+      status: org.subscriptionStatus,
+    };
+  }
+
+  return {
+    allowed: true,
+    reason: "active_subscription",
+    tier: org.subscriptionTier,
+  };
+}


### PR DESCRIPTION
Non-preview lessons now require a signed-in user whose organization has an
ACTIVE or TRIALING subscription. Lesson 1 of module 1 on each course is
flagged `preview: true` in frontmatter so prospects can try before they buy,
and locked lessons render a paywall with an enroll CTA and a login link
that preserves the callbackUrl so users land back on the lesson.

Replaces the Mastermind "Request an invite" Calendly button with an inline
email + name form that POSTs to a new `/api/mastermind/invite` endpoint.
Submissions are upserted into a new `MastermindInvite` Prisma model and a
notification email is fired to ops so we can follow up directly.