### PR TITLE
Add course paywall, Stripe product integration, and Mastermind email capture

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -69,6 +69,24 @@ model PasswordResetToken {
   createdAt DateTime @default(now())
 }
 
+// Grants a specific organization access to a specific course. Written
+// by the Stripe webhook on successful course purchases and read by
+// `getCourseAccess()` when gating lesson content. Service-tier purchases
+// (audit / sprint / managed) do NOT create rows here — course access is
+// strictly pay-per-course.
+model CourseEntitlement {
+  id             String       @id @default(cuid())
+  organizationId String
+  organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  courseSlug     String
+  source         String       @default("stripe_checkout")
+  stripePriceId  String?
+  grantedAt      DateTime     @default(now())
+
+  @@unique([organizationId, courseSlug])
+  @@index([courseSlug])
+}
+
 // Captures email sign-ups from the public Mastermind / community waitlist
 // form. These are leads to contact directly — they haven't paid yet and are
 // not linked to an Organization until/unless they convert via Stripe.
@@ -124,6 +142,7 @@ model Organization {
   subscriptionStatus SubscriptionStatus @default(ACTIVE)
   users              User[]
   subscriptions      Subscription[]
+  courseEntitlements CourseEntitlement[]
   oauthConnections   OAuthConnection[]
   automationInstances AutomationInstance[]
   createdAt          DateTime           @default(now())

--- a/scripts/migrations/2026-04-15-course-entitlement.sql
+++ b/scripts/migrations/2026-04-15-course-entitlement.sql
@@ -1,0 +1,64 @@
+-- One-off migration for the cases-paywall branch (2026-04-15).
+--
+-- Adds two tables introduced by the course paywall work:
+--
+--   CourseEntitlement — per-org, per-course access grants written by the
+--                       Stripe webhook on course purchases.
+--   MastermindInvite  — email waitlist for the Mastermind community form.
+--
+-- This repo uses `prisma db push` rather than a migrations folder, so this
+-- file is recorded here purely for audit / ops. You have two options to
+-- apply it to production:
+--
+--   1. (Preferred, matches repo convention)
+--        DATABASE_URL=<prod url> npx prisma db push
+--      Prisma will diff the live schema against prisma/schema.prisma and
+--      apply exactly the deltas below.
+--
+--   2. If you'd rather apply raw SQL by hand:
+--        psql "$DATABASE_URL" -f scripts/migrations/2026-04-15-course-entitlement.sql
+--
+-- Either way, make sure a recent database backup is in place first.
+-- Neither statement is destructive, but CREATE TABLE will fail if a table
+-- with the same name already exists, so the `db push` path is safer.
+
+-- CreateTable
+CREATE TABLE "CourseEntitlement" (
+    "id" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "courseSlug" TEXT NOT NULL,
+    "source" TEXT NOT NULL DEFAULT 'stripe_checkout',
+    "stripePriceId" TEXT,
+    "grantedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "CourseEntitlement_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "MastermindInvite" (
+    "id" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "name" TEXT,
+    "source" TEXT NOT NULL DEFAULT 'mastermind_page',
+    "notes" TEXT,
+    "contacted" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "MastermindInvite_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "CourseEntitlement_courseSlug_idx" ON "CourseEntitlement"("courseSlug");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "CourseEntitlement_organizationId_courseSlug_key" ON "CourseEntitlement"("organizationId", "courseSlug");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "MastermindInvite_email_key" ON "MastermindInvite"("email");
+
+-- CreateIndex
+CREATE INDEX "MastermindInvite_createdAt_idx" ON "MastermindInvite"("createdAt");
+
+-- AddForeignKey
+ALTER TABLE "CourseEntitlement" ADD CONSTRAINT "CourseEntitlement_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/src/app/(marketing)/courses/[courseSlug]/[moduleSlug]/[lessonSlug]/page.tsx
+++ b/src/app/(marketing)/courses/[courseSlug]/[moduleSlug]/[lessonSlug]/page.tsx
@@ -48,8 +48,9 @@ export default async function LessonPage({
 
   const { course, module: mod, lesson } = result;
 
-  // Gate everything that isn't explicitly marked as a free teaser.
-  const access = lesson.preview ? null : await getCourseAccess();
+  // Gate everything that isn't explicitly marked as a free teaser. Access
+  // is strictly per-course — service-tier buyers do not unlock courses.
+  const access = lesson.preview ? null : await getCourseAccess(course.slug);
   const locked = access !== null && !access.allowed;
 
   // Build flat lesson list for prev/next navigation across the whole course.
@@ -103,9 +104,7 @@ export default async function LessonPage({
                 reason={
                   access.reason === "unauthenticated"
                     ? "unauthenticated"
-                    : access.reason === "no_organization"
-                      ? "no_organization"
-                      : "inactive_subscription"
+                    : "not_entitled"
                 }
               />
             ) : (

--- a/src/app/(marketing)/courses/[courseSlug]/page.tsx
+++ b/src/app/(marketing)/courses/[courseSlug]/page.tsx
@@ -6,7 +6,15 @@ import { Footer } from "@/components/marketing/Footer";
 import { BookingProvider } from "@/components/marketing/BookingContext";
 import { LessonBody } from "@/components/courses/LessonBody";
 import { BookAuditButton } from "@/components/courses/BookAuditButton";
+import { EnrollButton } from "@/components/courses/EnrollButton";
 import { getCourse, listCourses, formatPrice } from "@/lib/courses";
+
+// Course slugs that are live on Stripe get a direct Enroll Now button.
+// Anything not in this map keeps the "talk to us about enrolling" flow.
+const COURSE_PLAN_BY_SLUG: Record<string, string> = {
+  "ai-for-agent-retention": "retention-course",
+  "ai-agency-ops-bootcamp": "bootcamp-course",
+};
 
 export function generateStaticParams() {
   return listCourses().map((c) => ({ courseSlug: c.slug }));
@@ -42,6 +50,8 @@ export default async function CourseLandingPage({
     (sum, m) => sum + m.lessons.length,
     0
   );
+
+  const coursePlan = COURSE_PLAN_BY_SLUG[course.slug];
 
   return (
     <BookingProvider>
@@ -85,13 +95,28 @@ export default async function CourseLandingPage({
                 <p className="text-4xl font-black text-white mb-6">
                   {formatPrice(course.price)}
                 </p>
-                <BookAuditButton
-                  label="Talk to us about enrolling"
-                  className="block w-full bg-blue-600 hover:bg-blue-700 text-white font-bold rounded-full px-6 py-3 text-center transition-colors"
-                />
-                <p className="text-xs text-neutral-500 mt-4 text-center">
-                  Enrollment opens Q2 2026. Book a call to get on the waitlist.
-                </p>
+                {coursePlan ? (
+                  <>
+                    <EnrollButton
+                      plan={coursePlan}
+                      label="Enroll now"
+                      className="block w-full bg-blue-600 hover:bg-blue-700 disabled:bg-blue-800 disabled:cursor-not-allowed text-white font-bold rounded-full px-6 py-3 text-center transition-colors"
+                    />
+                    <p className="text-xs text-neutral-500 mt-4 text-center">
+                      Secure checkout via Stripe · 30-day money-back guarantee
+                    </p>
+                  </>
+                ) : (
+                  <>
+                    <BookAuditButton
+                      label="Talk to us about enrolling"
+                      className="block w-full bg-blue-600 hover:bg-blue-700 text-white font-bold rounded-full px-6 py-3 text-center transition-colors"
+                    />
+                    <p className="text-xs text-neutral-500 mt-4 text-center">
+                      Enrollment opens Q2 2026. Book a call to get on the waitlist.
+                    </p>
+                  </>
+                )}
               </aside>
             </div>
 

--- a/src/app/(marketing)/courses/[courseSlug]/page.tsx
+++ b/src/app/(marketing)/courses/[courseSlug]/page.tsx
@@ -8,13 +8,7 @@ import { LessonBody } from "@/components/courses/LessonBody";
 import { BookAuditButton } from "@/components/courses/BookAuditButton";
 import { EnrollButton } from "@/components/courses/EnrollButton";
 import { getCourse, listCourses, formatPrice } from "@/lib/courses";
-
-// Course slugs that are live on Stripe get a direct Enroll Now button.
-// Anything not in this map keeps the "talk to us about enrolling" flow.
-const COURSE_PLAN_BY_SLUG: Record<string, string> = {
-  "ai-for-agent-retention": "retention-course",
-  "ai-agency-ops-bootcamp": "bootcamp-course",
-};
+import { planKeyForCourseSlug } from "@/lib/stripe";
 
 export function generateStaticParams() {
   return listCourses().map((c) => ({ courseSlug: c.slug }));
@@ -51,7 +45,7 @@ export default async function CourseLandingPage({
     0
   );
 
-  const coursePlan = COURSE_PLAN_BY_SLUG[course.slug];
+  const coursePlan = planKeyForCourseSlug(course.slug);
 
   return (
     <BookingProvider>

--- a/src/app/api/stripe/checkout/route.ts
+++ b/src/app/api/stripe/checkout/route.ts
@@ -1,6 +1,19 @@
 import { NextRequest, NextResponse } from "next/server";
+import type Stripe from "stripe";
 import { getStripe, PLAN_CONFIG, type PlanKey } from "@/lib/stripe";
 import { log } from "@/lib/logger";
+
+// Per-plan success URL overrides. Keys that aren't listed here fall back
+// to a generic success query-string on the homepage.
+const SUCCESS_URLS: Partial<Record<PlanKey, (origin: string) => string>> = {
+  // After paying for the audit, send customers straight to the 1-hour
+  // audit Calendly so they can schedule their session immediately.
+  audit: () => "https://calendly.com/joshrkay-ch88/1-hour-audit",
+  "retention-course": (origin) =>
+    `${origin}/courses/ai-for-agent-retention?checkout=success`,
+  "bootcamp-course": (origin) =>
+    `${origin}/courses/ai-agency-ops-bootcamp?checkout=success`,
+};
 
 export async function POST(req: NextRequest) {
   try {
@@ -11,34 +24,66 @@ export async function POST(req: NextRequest) {
     }
 
     const origin = req.headers.get("origin") || "https://renewalengineai.com";
+    const stripe = getStripe();
 
-    const lineItem = {
-      quantity: 1,
-      price_data: {
-        currency: "usd",
-        unit_amount: cfg.amount,
-        product_data: { name: cfg.name },
-        ...(cfg.mode === "subscription"
-          ? { recurring: { interval: cfg.interval as "month" } }
-          : {}),
-      },
-    };
+    // Resolve the line item. Prefer a real Stripe Product's default_price
+    // (set in the Stripe dashboard). Fall back to inline price_data built
+    // from the hard-coded PLAN_CONFIG amount when a plan hasn't been wired
+    // to a product yet.
+    let lineItem: Stripe.Checkout.SessionCreateParams.LineItem;
+    let effectiveMode: Stripe.Checkout.SessionCreateParams.Mode = cfg.mode;
 
-    // After paying for the audit, send customers straight to the 1-hour
-    // audit Calendly so they can schedule their session immediately.
+    const productId = (cfg as { productId?: string }).productId;
+    if (productId) {
+      const product = await stripe.products.retrieve(productId, {
+        expand: ["default_price"],
+      });
+      const defaultPrice = product.default_price;
+      if (!defaultPrice || typeof defaultPrice === "string") {
+        log.error(
+          `Stripe product ${productId} is missing an expanded default_price`
+        );
+        return NextResponse.json(
+          { error: "product_missing_default_price" },
+          { status: 500 }
+        );
+      }
+      if (!defaultPrice.active) {
+        return NextResponse.json(
+          { error: "product_price_inactive" },
+          { status: 500 }
+        );
+      }
+      lineItem = { price: defaultPrice.id, quantity: 1 };
+      // Trust Stripe's billing scheme over our local config: if the
+      // product's default price is recurring, run a subscription session.
+      effectiveMode = defaultPrice.recurring ? "subscription" : "payment";
+    } else {
+      lineItem = {
+        quantity: 1,
+        price_data: {
+          currency: "usd",
+          unit_amount: cfg.amount,
+          product_data: { name: cfg.name },
+          ...(cfg.mode === "subscription"
+            ? { recurring: { interval: cfg.interval as "month" } }
+            : {}),
+        },
+      };
+    }
+
     const successUrl =
-      plan === "audit"
-        ? "https://calendly.com/joshrkay-ch88/1-hour-audit"
-        : `${origin}/?checkout=success&plan=${plan}`;
+      SUCCESS_URLS[plan as PlanKey]?.(origin) ??
+      `${origin}/?checkout=success&plan=${plan}`;
 
-    const session = await getStripe().checkout.sessions.create({
-      mode: cfg.mode,
+    const session = await stripe.checkout.sessions.create({
+      mode: effectiveMode,
       line_items: [lineItem],
       success_url: successUrl,
       cancel_url: `${origin}/?checkout=cancel&plan=${plan}`,
       allow_promotion_codes: true,
       billing_address_collection: "auto",
-      customer_creation: cfg.mode === "payment" ? "always" : undefined,
+      customer_creation: effectiveMode === "payment" ? "always" : undefined,
       metadata: {
         plan,
         tier: cfg.tier,

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getStripe } from "@/lib/stripe";
+import { getStripe, PLAN_CONFIG, courseSlugForPlan, type PlanKey } from "@/lib/stripe";
 import { prisma } from "@/lib/db";
 import { randomBytes } from "crypto";
 import { sendWelcomeEmail } from "@/lib/email";
@@ -58,9 +58,19 @@ async function handleCheckoutCompleted(session: Stripe.Checkout.Session) {
   if (!email) return;
 
   const tier = (session.metadata?.tier || "AUDIT") as "AUDIT" | "SPRINT" | "MANAGED";
+  const planKey = (session.metadata?.plan || "") as PlanKey;
+  const planCfg = PLAN_CONFIG[planKey] as
+    | (typeof PLAN_CONFIG)[PlanKey]
+    | undefined;
   const name = session.customer_details?.name || null;
 
+  // Which course (if any) this purchase should unlock, and where to send
+  // the buyer after they set their password.
+  const courseSlug = planCfg ? courseSlugForPlan(planKey) : undefined;
+  const postPasswordCallbackUrl = courseSlug ? `/courses/${courseSlug}` : undefined;
+
   let user = await prisma.user.findUnique({ where: { email } });
+  let organizationId: string | null = null;
 
   if (!user) {
     // Create org and user without storing a plaintext password
@@ -72,6 +82,7 @@ async function handleCheckoutCompleted(session: Stripe.Checkout.Session) {
         subscriptionStatus: "ACTIVE",
       },
     });
+    organizationId = org.id;
 
     user = await prisma.user.create({
       data: {
@@ -101,8 +112,10 @@ async function handleCheckoutCompleted(session: Stripe.Checkout.Session) {
       },
     });
 
-    // Send welcome email with secure reset link (no password in email)
-    await sendWelcomeEmail(email, name, tier, resetToken);
+    // Send welcome email with secure reset link (no password in email).
+    // For course purchases we include a callbackUrl so the buyer lands
+    // back on the course they just paid for after setting their password.
+    await sendWelcomeEmail(email, name, tier, resetToken, postPasswordCallbackUrl);
 
     await logAudit({
       organizationId: org.id,
@@ -110,10 +123,11 @@ async function handleCheckoutCompleted(session: Stripe.Checkout.Session) {
       action: "user.created",
       resource: "User",
       resourceId: user.id,
-      metadata: { tier, source: "stripe_checkout" },
+      metadata: { tier, plan: planKey, source: "stripe_checkout" },
     });
   } else {
     if (user.organizationId) {
+      organizationId = user.organizationId;
       await prisma.organization.update({
         where: { id: user.organizationId },
         data: {
@@ -123,6 +137,26 @@ async function handleCheckoutCompleted(session: Stripe.Checkout.Session) {
         },
       });
     }
+  }
+
+  // Grant the course entitlement last, after the org definitely exists.
+  // Course purchases are strictly per-course — service-tier buyers do
+  // not pick up course access from this code path.
+  if (courseSlug && organizationId) {
+    await prisma.courseEntitlement.upsert({
+      where: {
+        organizationId_courseSlug: {
+          organizationId,
+          courseSlug,
+        },
+      },
+      create: {
+        organizationId,
+        courseSlug,
+        source: "stripe_checkout",
+      },
+      update: {},
+    });
   }
 }
 

--- a/src/app/set-password/page.tsx
+++ b/src/app/set-password/page.tsx
@@ -18,6 +18,14 @@ function SetPasswordForm() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const token = searchParams.get("token");
+  // Preserved through the welcome-email link so course buyers land back
+  // on the course they purchased after login. Only same-origin relative
+  // paths are honored (open-redirect guard).
+  const rawCallbackUrl = searchParams.get("callbackUrl");
+  const callbackUrl =
+    rawCallbackUrl && rawCallbackUrl.startsWith("/") && !rawCallbackUrl.startsWith("//")
+      ? rawCallbackUrl
+      : null;
 
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
@@ -53,7 +61,10 @@ function SetPasswordForm() {
       }
 
       setSuccess(true);
-      setTimeout(() => router.push("/login"), 2000);
+      const loginHref = callbackUrl
+        ? `/login?callbackUrl=${encodeURIComponent(callbackUrl)}`
+        : "/login";
+      setTimeout(() => router.push(loginHref), 2000);
     } catch {
       setError("An error occurred. Please try again.");
     } finally {

--- a/src/components/courses/EnrollButton.tsx
+++ b/src/components/courses/EnrollButton.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useState } from "react";
+
+type Props = {
+  plan: string;
+  label: string;
+  className?: string;
+};
+
+// Starts a Stripe Checkout Session for a course plan key
+// (e.g. "retention-course") and redirects the buyer to Stripe. Used on the
+// course landing page to sell directly instead of booking a call.
+export function EnrollButton({ plan, label, className }: Props) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleClick() {
+    if (loading) return;
+    setError(null);
+    setLoading(true);
+    try {
+      const res = await fetch("/api/stripe/checkout", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ plan }),
+      });
+      const data = (await res.json().catch(() => ({}))) as {
+        url?: string;
+        error?: string;
+      };
+      if (!res.ok || !data.url) {
+        setError("We couldn't open checkout. Please try again in a moment.");
+        setLoading(false);
+        return;
+      }
+      window.location.href = data.url;
+    } catch {
+      setError("We couldn't open checkout. Please try again in a moment.");
+      setLoading(false);
+    }
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={handleClick}
+        disabled={loading}
+        className={className}
+      >
+        {loading ? "Opening checkout…" : label}
+      </button>
+      {error && (
+        <p className="text-sm text-red-400 mt-3 text-center" role="alert">
+          {error}
+        </p>
+      )}
+    </>
+  );
+}

--- a/src/components/courses/LessonPaywall.tsx
+++ b/src/components/courses/LessonPaywall.tsx
@@ -6,10 +6,7 @@ type Props = {
   coursePrice: number;
   courseHref: string;
   returnHref: string;
-  reason:
-    | "unauthenticated"
-    | "no_organization"
-    | "inactive_subscription";
+  reason: "unauthenticated" | "not_entitled";
 };
 
 export function LessonPaywall({
@@ -34,9 +31,7 @@ export function LessonPaywall({
       <p className="text-neutral-300 text-lg mb-6 max-w-2xl">
         {isLoggedOut
           ? "Sign in with the account you used to enroll, or grab the course below to unlock every lesson, template, and prompt."
-          : reason === "inactive_subscription"
-            ? "Your subscription isn't active right now. Reactivate it to pick up where you left off."
-            : "We couldn't find an active subscription on your account. Enroll below to unlock every lesson, template, and prompt."}
+          : `Your account doesn't include ${courseTitle} yet. Enroll below to unlock every lesson, template, and prompt.`}
       </p>
 
       <div className="flex flex-wrap items-center gap-4 mb-8">

--- a/src/components/marketing/Pricing.tsx
+++ b/src/components/marketing/Pricing.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Check, Sparkles } from "lucide-react";
 import { useBooking } from "@/components/marketing/BookingContext";
@@ -62,14 +63,51 @@ const offers = [
 
 export function Pricing() {
   const { openBooking } = useBooking();
+  const [loadingPlan, setLoadingPlan] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
 
-  const handleCtaClick = (plan: string) => {
-    // Audit CTA goes directly to the 1-hour audit Calendly. Sprint and
-    // Managed plans open the 30-min consult booking modal.
+  const handleCtaClick = async (plan: string) => {
+    // Audit CTA goes directly to the 1-hour audit Calendly — clients
+    // still book the consult first and pay via the audit Stripe product
+    // on their own flow.
     if (plan === "audit") {
       window.open(AUDIT_CALENDLY_URL, "_blank", "noopener,noreferrer");
       return;
     }
+
+    // Sprint and Managed send the buyer straight to a Stripe Checkout
+    // session created from the live Stripe product's default price.
+    if (plan === "sprint" || plan === "managed") {
+      if (loadingPlan) return;
+      setError(null);
+      setLoadingPlan(plan);
+      try {
+        const res = await fetch("/api/stripe/checkout", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ plan }),
+        });
+        const data = (await res.json().catch(() => ({}))) as {
+          url?: string;
+          error?: string;
+        };
+        if (!res.ok || !data.url) {
+          setError(
+            "We couldn't open checkout. Please try again or book a call below."
+          );
+          setLoadingPlan(null);
+          return;
+        }
+        window.location.href = data.url;
+      } catch {
+        setError(
+          "We couldn't open checkout. Please try again or book a call below."
+        );
+        setLoadingPlan(null);
+      }
+      return;
+    }
+
     openBooking();
   };
 
@@ -122,13 +160,14 @@ export function Pricing() {
 
                 <Button
                   onClick={() => handleCtaClick(offer.key)}
+                  disabled={loadingPlan === offer.key}
                   className={`w-full text-lg py-7 rounded-full font-black transition-all ${
                     offer.popular
                       ? `bg-gradient-to-r ${offer.gradient} !text-white hover:scale-105 shadow-xl`
                       : "bg-black !text-white hover:bg-neutral-800"
                   }`}
                 >
-                  {offer.cta}
+                  {loadingPlan === offer.key ? "Opening checkout…" : offer.cta}
                 </Button>
               </div>
 
@@ -158,6 +197,15 @@ export function Pricing() {
             </div>
           ))}
         </div>
+
+        {error && (
+          <p
+            role="alert"
+            className="text-center text-red-600 font-semibold mt-8"
+          >
+            {error}
+          </p>
+        )}
 
         {/* Bottom CTA */}
         <div className="text-center mt-20">

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -37,7 +37,8 @@ export async function sendWelcomeEmail(
   email: string,
   name: string | null,
   tier: string,
-  resetToken: string
+  resetToken: string,
+  callbackUrl?: string
 ): Promise<void> {
   const tierLabels: Record<string, string> = {
     AUDIT: "AI-Powered Renewal Audit",
@@ -45,7 +46,14 @@ export async function sendWelcomeEmail(
     MANAGED: "Managed AI Operations",
   };
 
-  const resetUrl = `${APP_URL}/set-password?token=${resetToken}`;
+  // When provided, the set-password page forwards the callback to /login
+  // so the buyer lands on the page they bought (e.g. a course) rather
+  // than the generic dashboard after setting their password.
+  const callbackParam =
+    callbackUrl && callbackUrl.startsWith("/") && !callbackUrl.startsWith("//")
+      ? `&callbackUrl=${encodeURIComponent(callbackUrl)}`
+      : "";
+  const resetUrl = `${APP_URL}/set-password?token=${resetToken}${callbackParam}`;
 
   await sendEmail({
     to: email,

--- a/src/lib/entitlements.ts
+++ b/src/lib/entitlements.ts
@@ -1,21 +1,19 @@
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/db";
-import type { SubscriptionStatus, SubscriptionTier } from "@prisma/client";
 
 export type CourseAccess =
-  | { allowed: true; reason: "active_subscription"; tier: SubscriptionTier }
+  | { allowed: true; reason: "entitled" }
   | { allowed: false; reason: "unauthenticated" }
   | { allowed: false; reason: "no_organization" }
-  | { allowed: false; reason: "inactive_subscription"; status: SubscriptionStatus };
+  | { allowed: false; reason: "not_entitled" };
 
-// A user has access to paid course content if they are signed in and their
-// organization has a subscription in a state that should grant access.
-// We intentionally treat ACTIVE and TRIALING as entitled. CANCELED and
-// PAST_DUE are not. Any paid tier (AUDIT / SPRINT / MANAGED) currently
-// includes the course library — if that changes, narrow the check here.
-const ENTITLED_STATUSES: SubscriptionStatus[] = ["ACTIVE", "TRIALING"];
-
-export async function getCourseAccess(): Promise<CourseAccess> {
+// Access to paid course content is strictly per-course. A user unlocks a
+// course by purchasing it through Stripe — the webhook records a row in
+// `CourseEntitlement` that this helper reads. Service-tier subscriptions
+// (audit / sprint / managed) do NOT imply course access.
+export async function getCourseAccess(
+  courseSlug: string
+): Promise<CourseAccess> {
   const session = await auth();
   if (!session?.user?.id) {
     return { allowed: false, reason: "unauthenticated" };
@@ -27,26 +25,19 @@ export async function getCourseAccess(): Promise<CourseAccess> {
     return { allowed: false, reason: "no_organization" };
   }
 
-  const org = await prisma.organization.findUnique({
-    where: { id: organizationId },
-    select: { subscriptionTier: true, subscriptionStatus: true },
+  const entitlement = await prisma.courseEntitlement.findUnique({
+    where: {
+      organizationId_courseSlug: {
+        organizationId,
+        courseSlug,
+      },
+    },
+    select: { id: true },
   });
 
-  if (!org) {
-    return { allowed: false, reason: "no_organization" };
+  if (!entitlement) {
+    return { allowed: false, reason: "not_entitled" };
   }
 
-  if (!ENTITLED_STATUSES.includes(org.subscriptionStatus)) {
-    return {
-      allowed: false,
-      reason: "inactive_subscription",
-      status: org.subscriptionStatus,
-    };
-  }
-
-  return {
-    allowed: true,
-    reason: "active_subscription",
-    tier: org.subscriptionTier,
-  };
+  return { allowed: true, reason: "entitled" };
 }

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -60,6 +60,7 @@ export const PLAN_CONFIG = {
     name: "AI for Agent Retention",
     interval: null,
     tier: "AUDIT" as const,
+    courseSlug: "ai-for-agent-retention",
   },
   "bootcamp-course": {
     productId: "prod_ULHbSayZppnUZZ",
@@ -68,7 +69,24 @@ export const PLAN_CONFIG = {
     name: "AI Agency Operations Bootcamp",
     interval: null,
     tier: "AUDIT" as const,
+    courseSlug: "ai-agency-ops-bootcamp",
   },
 } as const;
 
 export type PlanKey = keyof typeof PLAN_CONFIG;
+
+// Returns the course slug unlocked by a plan, or undefined if the plan
+// isn't a course purchase. Used by the webhook to decide when to create
+// a CourseEntitlement row and by the course page to pick a plan key.
+export function courseSlugForPlan(key: PlanKey): string | undefined {
+  const cfg = PLAN_CONFIG[key] as { courseSlug?: string };
+  return cfg.courseSlug;
+}
+
+export function planKeyForCourseSlug(slug: string): PlanKey | undefined {
+  for (const key of Object.keys(PLAN_CONFIG) as PlanKey[]) {
+    const cfg = PLAN_CONFIG[key] as { courseSlug?: string };
+    if (cfg.courseSlug === slug) return key;
+  }
+  return undefined;
+}

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -13,8 +13,24 @@ export function getStripe(): Stripe {
   return _stripe;
 }
 
+// Plan config drives `/api/stripe/checkout`. Each entry can source the
+// actual Stripe price in one of two ways:
+//
+//   1. `productId` — the Stripe Product ID (prod_…). At checkout time we
+//      retrieve the product with `default_price` expanded and use that
+//      price in the line item. This lets pricing live in Stripe without
+//      redeploying code.
+//
+//   2. `amount` — a hard-coded cents amount. Used as a fallback when
+//      `productId` is not set (inline `price_data`). Kept for plans we
+//      haven't yet migrated to a real Stripe product.
+//
+// `amount` is also what the marketing UI reads for display, so keep it
+// roughly in sync with the Stripe-side price even when productId wins at
+// checkout time.
 export const PLAN_CONFIG = {
   audit: {
+    productId: "prod_ULHZKqC7l4xCSt",
     amount: 150000,
     mode: "payment" as const,
     name: "AI-Powered Renewal Audit",
@@ -22,6 +38,7 @@ export const PLAN_CONFIG = {
     tier: "AUDIT" as const,
   },
   sprint: {
+    productId: "prod_ULHZWucDiB4kPd",
     amount: 600000,
     mode: "payment" as const,
     name: "AI Automation Build & Launch",
@@ -29,11 +46,28 @@ export const PLAN_CONFIG = {
     tier: "SPRINT" as const,
   },
   managed: {
+    productId: "prod_ULHZXJ5xHZHUgw",
     amount: 250000,
     mode: "subscription" as const,
     name: "Managed AI Operations",
     interval: "month" as const,
     tier: "MANAGED" as const,
+  },
+  "retention-course": {
+    productId: "prod_ULHcrd2kItHf88",
+    amount: 39700,
+    mode: "payment" as const,
+    name: "AI for Agent Retention",
+    interval: null,
+    tier: "AUDIT" as const,
+  },
+  "bootcamp-course": {
+    productId: "prod_ULHbSayZppnUZZ",
+    amount: 79700,
+    mode: "payment" as const,
+    name: "AI Agency Operations Bootcamp",
+    interval: null,
+    tier: "AUDIT" as const,
   },
 } as const;
 


### PR DESCRIPTION
## Summary

- **Course paywall**: Lessons are gated behind per-course entitlements (`CourseEntitlement` table). First lesson of module 1 on each course is a free preview; everything else requires purchase. Service-tier buyers (audit/sprint/managed) do NOT get course access — courses are strictly pay-per-course.
- **Stripe products wired into CTAs**: All 5 live Stripe products (`prod_ULHZKqC7l4xCSt`, `prod_ULHZWucDiB4kPd`, `prod_ULHZXJ5xHZHUgw`, `prod_ULHcrd2kItHf88`, `prod_ULHbSayZppnUZZ`) registered in `PLAN_CONFIG`. Checkout route resolves each product's `default_price` from Stripe at runtime. Sprint + Managed pricing buttons go to Stripe Checkout; audit stays on Calendly. Both course pages show "Enroll now" → Stripe Checkout.
- **Mastermind email capture**: Replaced "Request an Invite" booking button with an inline email/name form. Submissions upserted into new `MastermindInvite` table and a notification email fires to ops.
- **Buyer redirect flow**: Course buyers land back on their course after setting a password (welcome email → set-password → login → course page), with open-redirect guards at every boundary.

## Database migration required

Two new tables: `CourseEntitlement` and `MastermindInvite`. Run before deploying:

```bash
DATABASE_URL="<prod url>" npx prisma db push
```

Or apply `scripts/migrations/2026-04-15-course-entitlement.sql` via the Supabase SQL Editor.

## Key files

| Area | Files |
|------|-------|
| Paywall gate | `src/lib/entitlements.ts`, `src/components/courses/LessonPaywall.tsx` |
| Stripe config | `src/lib/stripe.ts`, `src/app/api/stripe/checkout/route.ts` |
| Webhook (entitlements) | `src/app/api/stripe/webhook/route.ts` |
| Mastermind form | `src/components/marketing/MastermindInviteForm.tsx`, `src/app/api/mastermind/invite/route.ts` |
| Course pages | `src/app/(marketing)/courses/[courseSlug]/page.tsx`, `src/app/(marketing)/courses/[courseSlug]/[moduleSlug]/[lessonSlug]/page.tsx` |
| Schema | `prisma/schema.prisma` |

## Test plan

- [ ] Run DB migration (`prisma db push` or SQL file)
- [ ] Verify each Stripe product has a `default_price` set in the Stripe dashboard
- [ ] Test course purchase flow end-to-end with test card `4242 4242 4242 4242` (pay → welcome email → set password → redirected to course → lessons unlocked)
- [ ] Test sprint/managed checkout from `/#pricing` section
- [ ] Verify audit CTA still opens Calendly (not Stripe)
- [ ] Visit a non-preview lesson while logged out → should see paywall
- [ ] Visit preview lesson (module 1, lesson 1) while logged out → should render content
- [ ] Submit email on `/mastermind` → should see success state + check `MastermindInvite` table for row
- [ ] Verify Stripe webhook endpoint returns 200 on `checkout.session.completed` events

https://claude.ai/code/session_012JQYVLFSgHJtAaB5FC6Qxi