### PR TITLE
docs: add Content, GEO & SCO growth plan

### DIFF
--- a/content/resources/_backlog.json
+++ b/content/resources/_backlog.json
@@ -107,6 +107,168 @@
       "category": "Strategy",
       "priority": 6,
       "status": "pending"
+    },
+    {
+      "slug": "ai-for-insurance-agencies-guide",
+      "title": "AI for Insurance Agencies: The 2026 Playbook for Independent Agents",
+      "description": "The pillar guide to AI for insurance agencies — what to automate first, where it pays off, what it costs, and how to roll it out without breaking your AMS or your team.",
+      "primaryKeyword": "AI for insurance agencies",
+      "category": "Strategy",
+      "priority": 10,
+      "status": "pending"
+    },
+    {
+      "slug": "applied-epic-ai-automation",
+      "title": "Applied Epic AI Automation: What You Can Wire Up and How",
+      "description": "A practical guide to Applied Epic AI automation — the data you can read and write back, the activity-log patterns, and the renewal and lead-response workflows that actually stick.",
+      "primaryKeyword": "Applied Epic AI automation",
+      "category": "Integrations",
+      "priority": 10,
+      "status": "pending"
+    },
+    {
+      "slug": "hawksoft-ai-automation",
+      "title": "HawkSoft AI Automation: A Practical Guide for Independent Agencies",
+      "description": "How to layer AI renewal, lead-response, and quote follow-up automation on top of HawkSoft CMS using exports and the API, with opt-out enforcement and write-back patterns.",
+      "primaryKeyword": "HawkSoft AI automation",
+      "category": "Integrations",
+      "priority": 9,
+      "status": "pending"
+    },
+    {
+      "slug": "ezlynx-ai-automation",
+      "title": "EZLynx AI Automation: Renewals, Leads, and Quote Follow-Up",
+      "description": "What AI automation looks like on EZLynx — pulling policy and rating data, automating renewal and quote follow-up sequences, and writing activity back to the client record.",
+      "primaryKeyword": "EZLynx AI automation",
+      "category": "Integrations",
+      "priority": 9,
+      "status": "pending"
+    },
+    {
+      "slug": "best-ai-tools-for-insurance-agencies",
+      "title": "The Best AI Tools for Insurance Agencies in 2026 (Honest Breakdown)",
+      "description": "An honest breakdown of the best AI tools for insurance agencies by job to be done — renewals, lead response, quoting, and service — with where each fits and where it falls short.",
+      "primaryKeyword": "best AI tools for insurance agencies",
+      "category": "Strategy",
+      "priority": 9,
+      "status": "pending"
+    },
+    {
+      "slug": "insurance-renewal-email-templates",
+      "title": "9 Insurance Renewal Email Templates (and the Cadence That Binds)",
+      "description": "Nine copy-and-paste insurance renewal email templates mapped to the 60/30/14/7-day cadence, with the personalization details that lift retention.",
+      "primaryKeyword": "insurance renewal email templates",
+      "category": "Retention",
+      "priority": 9,
+      "status": "pending"
+    },
+    {
+      "slug": "retention-benchmarks-independent-agencies-2026",
+      "title": "Insurance Retention Benchmarks for Independent Agencies (2026)",
+      "description": "What good retention looks like for independent P&C agencies in 2026, by line of business and book size, plus how to close the gap between your numbers and the benchmark.",
+      "primaryKeyword": "insurance retention benchmarks",
+      "category": "Retention",
+      "priority": 9,
+      "status": "pending"
+    },
+    {
+      "slug": "after-hours-insurance-lead-capture",
+      "title": "Stop Losing After-Hours Leads: The 24/7 Capture Playbook",
+      "description": "Most insurance leads arrive after hours and go to whoever answers first. The workflow for capturing and responding to after-hours insurance leads in under 60 seconds.",
+      "primaryKeyword": "after hours insurance lead capture",
+      "category": "Growth",
+      "priority": 8,
+      "status": "pending"
+    },
+    {
+      "slug": "x-date-marketing-strategy",
+      "title": "X-Date Marketing: How to Win Renewals Before the Incumbent Reacts",
+      "description": "An X-date marketing strategy for independent agencies — how to time outreach around expiration dates so you reach prospects before the incumbent agent does.",
+      "primaryKeyword": "insurance X-date marketing",
+      "category": "Growth",
+      "priority": 8,
+      "status": "pending"
+    },
+    {
+      "slug": "measuring-ai-roi-insurance-agency",
+      "title": "How to Measure AI ROI in an Insurance Agency (Without Fooling Yourself)",
+      "description": "A defensible way to measure AI ROI in an insurance agency — the baseline metrics to capture first, the attribution traps to avoid, and the math that holds up to an owner's scrutiny.",
+      "primaryKeyword": "AI ROI insurance agency",
+      "category": "Strategy",
+      "priority": 8,
+      "status": "pending"
+    },
+    {
+      "slug": "why-agencies-outgrow-gohighlevel",
+      "title": "Why Insurance Agencies Outgrow GoHighLevel (and What Comes Next)",
+      "description": "GoHighLevel gets agencies started, then the insurance-specific gaps show up. Where a generic CRM stops fitting P&C workflows and what a done-for-you alternative changes.",
+      "primaryKeyword": "GoHighLevel insurance agency alternative",
+      "category": "Strategy",
+      "priority": 8,
+      "status": "pending"
+    },
+    {
+      "slug": "certificate-of-insurance-automation",
+      "title": "Certificate of Insurance Automation: Cutting COI Turnaround to Minutes",
+      "description": "How AI and workflow automation cut certificate of insurance turnaround from hours to minutes, with the request-intake, template, and approval patterns that keep it compliant.",
+      "primaryKeyword": "certificate of insurance automation",
+      "category": "Operations",
+      "priority": 7,
+      "status": "pending"
+    },
+    {
+      "slug": "ai-cross-sell-personal-to-commercial",
+      "title": "Cross-Selling Personal Lines Clients into Commercial with AI",
+      "description": "The signals that flag a personal-lines client who is also a business owner, and the AI-driven cross-sell sequence that opens the commercial conversation at the right moment.",
+      "primaryKeyword": "insurance cross-sell automation personal commercial",
+      "category": "Retention",
+      "priority": 7,
+      "status": "pending"
+    },
+    {
+      "slug": "book-of-business-health-metrics",
+      "title": "The 6 Book-of-Business Health Metrics Every Agency Should Track",
+      "description": "The six book-of-business health metrics that predict where an independent agency is about to leak revenue — retention, policies per household, lapse rate, and more.",
+      "primaryKeyword": "book of business health metrics insurance",
+      "category": "Operations",
+      "priority": 7,
+      "status": "pending"
+    },
+    {
+      "slug": "ai-for-small-insurance-agencies",
+      "title": "AI for Small Insurance Agencies: A Playbook for Books Under 500 Policies",
+      "description": "AI for small insurance agencies — where to start when you have under 500 policies and no ops team, and the two automations that pay for themselves first.",
+      "primaryKeyword": "AI for small insurance agency",
+      "category": "Strategy",
+      "priority": 7,
+      "status": "pending"
+    },
+    {
+      "slug": "csr-capacity-without-hiring",
+      "title": "Add CSR Capacity Without Hiring: Where AI Actually Helps",
+      "description": "How to add CSR capacity without hiring by handing the repetitive renewal, follow-up, and service-triage work to AI — and where a human still has to stay in the loop.",
+      "primaryKeyword": "insurance CSR capacity AI",
+      "category": "Operations",
+      "priority": 6,
+      "status": "pending"
+    },
+    {
+      "slug": "building-client-trust-with-ai-outreach",
+      "title": "Keeping Outreach Human: Building Client Trust When AI Sends the Message",
+      "description": "How to keep AI-assisted insurance outreach feeling human — voice, review gates, and disclosure choices that build client trust instead of eroding it.",
+      "primaryKeyword": "AI insurance client communication trust",
+      "category": "Operations",
+      "priority": 6,
+      "status": "pending"
+    },
+    {
+      "slug": "how-ai-engines-recommend-insurance-software",
+      "title": "How AI Engines Decide Which Insurance Software to Recommend",
+      "description": "What ChatGPT, Perplexity, and Google AI Overviews look at when they recommend insurance software, and what that means for how agencies evaluate vendors in 2026.",
+      "primaryKeyword": "AI recommendations insurance software",
+      "category": "Strategy",
+      "priority": 6,
+      "status": "pending"
     }
   ]
 }

--- a/content/resources/_backlog.json
+++ b/content/resources/_backlog.json
@@ -115,7 +115,7 @@
       "primaryKeyword": "AI for insurance agencies",
       "category": "Strategy",
       "priority": 10,
-      "status": "pending"
+      "status": "published"
     },
     {
       "slug": "applied-epic-ai-automation",
@@ -124,7 +124,7 @@
       "primaryKeyword": "Applied Epic AI automation",
       "category": "Integrations",
       "priority": 10,
-      "status": "pending"
+      "status": "published"
     },
     {
       "slug": "hawksoft-ai-automation",
@@ -133,7 +133,7 @@
       "primaryKeyword": "HawkSoft AI automation",
       "category": "Integrations",
       "priority": 9,
-      "status": "pending"
+      "status": "published"
     },
     {
       "slug": "ezlynx-ai-automation",
@@ -142,7 +142,7 @@
       "primaryKeyword": "EZLynx AI automation",
       "category": "Integrations",
       "priority": 9,
-      "status": "pending"
+      "status": "published"
     },
     {
       "slug": "best-ai-tools-for-insurance-agencies",

--- a/content/resources/ai-for-insurance-agencies-guide.md
+++ b/content/resources/ai-for-insurance-agencies-guide.md
@@ -90,7 +90,7 @@ The market is full of demos. A few questions separate the operators from the dem
 - **Can I see the outreach before it goes out?** You should be able to, at least until you trust it.
 - **Is there a human accountable for the results?** Software with nobody behind it tends to drift.
 
-If you are sizing the build-versus-buy decision, our piece on [evaluating AI vendors](/resources/evaluating-ai-vendors-insurance-agencies) goes deeper on the red flags.
+If you are weighing the build-versus-buy decision, our breakdown of [AI automation versus hiring another CSR](/compare/renewalengineai-vs-hiring-csr) runs the cost math.
 
 ## Frequently Asked Questions
 

--- a/content/resources/ai-for-insurance-agencies-guide.md
+++ b/content/resources/ai-for-insurance-agencies-guide.md
@@ -1,7 +1,7 @@
 ---
 title: "AI for Insurance Agencies: The 2026 Playbook for Independent Agents"
 slug: "ai-for-insurance-agencies-guide"
-description: "What AI for insurance agencies actually does in 2026 — the use cases worth automating first, what it costs, how it fits your AMS, and the 90-day rollout that works."
+description: "What AI for insurance agencies actually does in 2026: the use cases worth automating first, what it costs, how it fits your AMS, and the 90-day rollout that works."
 publishedAt: "2026-05-31"
 category: "Strategy"
 primaryKeyword: "AI for insurance agencies"
@@ -91,6 +91,32 @@ The market is full of demos. A few questions separate the operators from the dem
 - **Is there a human accountable for the results?** Software with nobody behind it tends to drift.
 
 If you are sizing the build-versus-buy decision, our piece on [evaluating AI vendors](/resources/evaluating-ai-vendors-insurance-agencies) goes deeper on the red flags.
+
+## Frequently Asked Questions
+
+### What is AI for insurance agencies?
+
+AI for insurance agencies is software that reads your agency management system, drafts client outreach, and routes the right work to the right person automatically. In practice it runs renewal campaigns, responds to new leads in under 60 seconds, follows up on quotes, and flags cross-sell opportunities, while producers keep the judgment calls and relationships.
+
+### How much does AI cost for an insurance agency?
+
+It ranges from a few hundred dollars a month in tool subscriptions if you build it yourself, to a done-for-you engagement where you pay for the build and ongoing management. The number that matters is the comparison: a fully loaded CSR runs $60,000 to $80,000 a year and works one channel at a time, while AI handles many at once.
+
+### Will AI replace insurance agents or CSRs?
+
+No. AI removes the data entry and routine follow-up that eats most of the day. It does not handle the coverage conversation, the claim a client is panicking about, or the relationship that wins a referral. The agencies that do this well redeploy their people to that higher-value work, not out the door.
+
+### What should an agency automate first?
+
+Renewals and instant lead response. Renewals because 8 to 12% of the book lapses every year from simple lack of contact, and lead response because responding within a minute is associated with a large jump in conversions. Both have clear ROI and a clean way to measure it.
+
+### Does AI work with my AMS?
+
+Yes, on the major independent platforms. We have specific guides for [Applied Epic](/resources/applied-epic-ai-automation), [HawkSoft](/resources/hawksoft-ai-automation), and [EZLynx](/resources/ezlynx-ai-automation). The rule that matters is write-back: every automated touch should be logged to your AMS so producers see the full history in one place.
+
+### How long does it take to see results?
+
+A focused build goes live in two to three weeks. Lead-response improvements show up immediately because the change is mechanical. Retention lift takes longer to read, usually landing around month four or five once the first full renewal cohort has been through the cadence.
 
 ## Where to Start
 

--- a/content/resources/ai-for-insurance-agencies-guide.md
+++ b/content/resources/ai-for-insurance-agencies-guide.md
@@ -1,0 +1,99 @@
+---
+title: "AI for Insurance Agencies: The 2026 Playbook for Independent Agents"
+slug: "ai-for-insurance-agencies-guide"
+description: "What AI for insurance agencies actually does in 2026 — the use cases worth automating first, what it costs, how it fits your AMS, and the 90-day rollout that works."
+publishedAt: "2026-05-31"
+category: "Strategy"
+primaryKeyword: "AI for insurance agencies"
+readTime: 13
+related:
+  - "applied-epic-ai-automation"
+  - "hawksoft-ai-automation"
+  - "ezlynx-ai-automation"
+  - "ai-renewal-automation-playbook"
+---
+
+# AI for Insurance Agencies: The 2026 Playbook for Independent Agents
+
+Every independent agency owner has heard that AI is going to change the business. Most have also sat through a demo that looked impressive and changed nothing. The gap between those two facts is where this guide lives.
+
+AI for insurance agencies is not a chatbot bolted onto your website. It is a set of systems that watch your book, draft the outreach, and route the right work to the right person at the right time, so renewals stop slipping, leads get answered in seconds, and quotes actually get followed up. Done right, agencies see 15-20% higher retention and respond to new leads in under 60 seconds. Done wrong, it is a subscription you forget you are paying for.
+
+The timing matters. In the 2026 Big "I" Agents Council for Technology survey, only about 8% of independent agencies had AI embedded in their daily workflow, while two-thirds said they plan to increase their AI use over the next year ([Independent Insurance Agents & Brokers of America](https://www.independentagent.com/news/two-thirds-of-independent-agents-plan-to-increase-ai-use-this-year/)). Acting now still makes you early. It will not for long.
+
+This is the practical version: what to automate first, what it costs, how it fits the AMS you already run, and how to roll it out in 90 days without breaking anything.
+
+## What "AI for Insurance Agencies" Actually Means
+
+Strip away the marketing and AI in an agency does three things well: it reads, it writes, and it decides what is worth a human's attention. Everything useful follows from those three.
+
+- **It reads.** It pulls policy data, x-dates, claim history, and inbound messages from your AMS and inbox, and turns the mess into a clean, prioritized list.
+- **It writes.** It drafts renewal outreach, quote follow-ups, and service replies in your agency's voice, referencing the client's actual policy instead of "Dear Valued Customer."
+- **It decides.** It routes the high-value or at-risk accounts to a producer and handles the routine ones automatically, so nobody spends Tuesday morning copying data between tabs.
+
+What it does not do is replace the producer. The judgment calls, the relationships, the awkward coverage conversation before a renewal: those stay human. AI removes the 60% of the day that is data entry and follow-up so the producer can spend more time on the 40% that actually closes business.
+
+## The Use Cases Worth Automating First
+
+Not every workflow is worth automating, and trying to automate all of them at once is the fastest way to ship nothing. These are the four that pay for themselves first, in rough order of ROI.
+
+| Use case | What it fixes | Typical impact |
+|----------|---------------|----------------|
+| Renewal outreach | The 8-12% of the book that lapses from no contact | 15-20% retention lift |
+| Instant lead response | Leads that go cold before anyone calls | Sub-60-second response, more binds |
+| Quote follow-up | Quoted prospects who never hear back | Higher bind rate on existing quotes |
+| Cross-sell triggers | Monoline clients who should have 3 policies | More policies per household |
+
+Start with renewals and lead response. Renewals because the leak is already costing you real commission every month. Lead response because the math is overwhelming: a Harvard Business Review analysis of 1.25 million leads found firms that responded within an hour were nearly 7 times more likely to have a meaningful conversation with a decision-maker than those who waited, yet the average first response time was 42 hours. Separately, a Velocify study of 3.5 million leads found that calling a new lead within one minute produced 391% more conversions than waiting. Speed alone is an edge most agencies are leaving on the table.
+
+If you want the deep version of either, we have full playbooks on [renewal automation](/resources/ai-renewal-automation-playbook) and [instant lead response](/resources/instant-lead-response-under-60-seconds).
+
+## What AI Costs an Agency (and What It Saves)
+
+There are two honest ways to get AI into an agency, and they cost very different things.
+
+**Build it yourself.** You can stitch together off-the-shelf tools, a comparative rater, and some automation software for a few hundred dollars a month in subscriptions. The real cost is time: someone has to learn the tools, wire them to your AMS, write the prompts, and maintain it when something breaks. For a hands-on agency with a tech-comfortable team member, this is a legitimate path. Our [Agency Operations Bootcamp](/courses/ai-agency-ops-bootcamp) exists for exactly these people.
+
+**Have it built and run for you.** A done-for-you engagement skips the learning curve: an audit to find the leaks, a build to wire the systems to your AMS, and ongoing management so it keeps working. The trade-off is straightforward. You pay for outcomes instead of paying in hours.
+
+Either way, the number that matters is not the subscription. It is the comparison to the alternative. A fully loaded CSR hire runs $60,000-80,000 a year and can only work one phone at a time. AI handles the after-hours lead, the 60-day renewal touch, and the quote follow-up simultaneously, and it does not take vacation during renewal season. The question is rarely "can we afford AI" and more often "can we afford to keep doing this by hand."
+
+## How AI Fits Your AMS
+
+This is where most agency AI projects quietly die. A tool that cannot read from and write back to your agency management system creates a second system of record, and a second system of record is worse than no system at all.
+
+Good AI integrates natively with the AMS you already run:
+
+- **Applied Epic** agencies connect through Applied's data exports and available APIs, with outreach activity written back so producers see the full history. See the [Applied Epic AI automation guide](/resources/applied-epic-ai-automation).
+- **HawkSoft** agencies integrate via scheduled exports and the HawkSoft API, with opt-out flags enforced from the client record. See the [HawkSoft AI automation guide](/resources/hawksoft-ai-automation).
+- **EZLynx** agencies pull policy and rating data and write activity back to the client record. See the [EZLynx AI automation guide](/resources/ezlynx-ai-automation).
+
+The non-negotiable rule: every automated touch gets logged back to the AMS. If your producer cannot open a client in Epic or HawkSoft and see exactly what the system said and when, you have built a liability, not an asset. The full integration patterns live in our [AMS + AI integration guide](/resources/ams-ai-integration-guide).
+
+## The 90-Day Rollout
+
+The agencies that succeed with AI treat it like hiring, not like buying software. You onboard it, you supervise it, and you expand its responsibilities as it earns trust.
+
+1. **Days 1-30: One workflow, supervised.** Pick renewals. Turn on the 60- and 30-day touches in draft mode, where the AI writes and a human approves before anything sends. You are checking voice and accuracy, not chasing volume.
+2. **Days 31-60: Loosen the leash.** Once the drafts are consistently good, let the early touches send automatically and keep humans on the 14- and 7-day calls. Add instant lead response as the second workflow.
+3. **Days 61-90: Measure and expand.** Compare retention and response time to your pre-AI baseline. If the numbers moved, add quote follow-up and cross-sell triggers. If they did not, fix the workflow you have before adding another.
+
+The mistake to avoid is flipping everything to fully automatic on day one. Trust is earned one workflow at a time, and an AI that sends a wrong renewal quote to 200 clients sets the whole project back months.
+
+## What to Look For (and What to Avoid)
+
+The market is full of demos. A few questions separate the operators from the demoware:
+
+- **Does it write back to my AMS?** If the answer is vague, walk.
+- **Whose voice does the outreach use?** It should sound like your agency, not a generic SaaS template.
+- **What happens when it is unsure?** A good system flags and escalates. A bad one guesses and sends.
+- **Can I see the outreach before it goes out?** You should be able to, at least until you trust it.
+- **Is there a human accountable for the results?** Software with nobody behind it tends to drift.
+
+If you are sizing the build-versus-buy decision, our piece on [evaluating AI vendors](/resources/evaluating-ai-vendors-insurance-agencies) goes deeper on the red flags.
+
+## Where to Start
+
+AI for insurance agencies is not one decision. It is a sequence: pick the workflow that is leaking the most money, automate it in draft mode, supervise it until it earns trust, then expand. Renewals and lead response are almost always the place to start because the leaks are large and the math is undeniable.
+
+If you would rather see exactly where your own book is leaking before you commit to anything, [book a free renewal audit](/#pricing) and we will put numbers to it. The agencies that win the next few years will not be the ones with the fanciest AI. They will be the ones who pointed a simple system at a real problem and let it run.

--- a/content/resources/applied-epic-ai-automation.md
+++ b/content/resources/applied-epic-ai-automation.md
@@ -1,0 +1,74 @@
+---
+title: "Applied Epic AI Automation: What You Can Wire Up and How"
+slug: "applied-epic-ai-automation"
+description: "A practical guide to Applied Epic AI automation: the data you can read, how outreach gets written back to Activities, and the renewal and lead-response workflows that stick."
+publishedAt: "2026-05-31"
+category: "Integrations"
+primaryKeyword: "Applied Epic AI automation"
+readTime: 10
+related:
+  - "ams-ai-integration-guide"
+  - "ai-for-insurance-agencies-guide"
+  - "ai-renewal-automation-playbook"
+---
+
+# Applied Epic AI Automation: What You Can Wire Up and How
+
+Applied Epic is the system of record for a large share of mid-size and larger independent agencies. By agency count it runs an estimated 31% of independent agencies with 10 or more employees ([2026 AMS market data](https://www.quotesweep.com/blog/ams-comparison-2026)), which is exactly why AI automation on top of it is worth getting right. Epic already holds the clean policy data, the x-dates, and the activity history. The job of AI is not to replace any of that. It is to read it, act on it, and write every touch back so the Activities log stays the single source of truth.
+
+This guide covers what you can actually automate on Applied Epic, how the integration works in practice, and where these projects tend to break.
+
+## Where Your Data Lives in Applied Epic
+
+Before you automate anything, it helps to know which parts of Epic the AI reads from and writes to. Four areas matter:
+
+- **Policies and x-dates.** Coverage type, premium, carrier, and the expiration date that drives every renewal cadence.
+- **Client and contact records.** Names, emails, phone numbers, and the communication preferences that govern who you are allowed to contact and how.
+- **Activities.** Epic's running log of every interaction. This is where automated outreach must be written back so producers see the full history without leaving Epic.
+- **Attachments and notes.** Context that makes outreach specific instead of generic.
+
+If you run Applied Analytics, you already have a structured way to export much of this. Combined with Applied's API access where it is available, that is enough to drive a renewal and lead-response engine.
+
+## What You Can Automate on Applied Epic
+
+The highest-ROI workflows are the same ones that pay off on any AMS, but Epic's structured data makes them especially clean to run.
+
+| Workflow | What Epic provides | What the AI does |
+|----------|--------------------|------------------|
+| Renewal outreach | X-dates, policy detail, carrier | Drafts the 60/30/14/7-day cadence, routes at-risk accounts to a producer |
+| Instant lead response | Inbound contact records | Replies in under 60 seconds, logs the contact as an Activity |
+| Quote follow-up | Open opportunities, policy data | Runs a multi-touch sequence until the prospect responds or binds |
+| Cross-sell triggers | Policy mix per client | Flags monoline households for a coverage conversation |
+
+Renewals are almost always the place to start. The four-touch cadence is described in full in our [renewal automation playbook](/resources/ai-renewal-automation-playbook), and Epic's x-date data is what makes it run without anyone maintaining a spreadsheet.
+
+## How the Integration Actually Works
+
+There are two channels for getting data in and out of Epic, and a real deployment usually uses both.
+
+1. **Scheduled exports.** Applied Analytics and Epic's reporting can produce structured extracts of renewal lists, client contacts, and policy detail on a schedule. This is the reliable backbone: it does not depend on a live connection and it is easy to audit.
+2. **Direct API.** Where Applied API access is available, it allows closer-to-real-time reads and, importantly, writing Activities back into Epic programmatically.
+
+The pattern that works: read the book on a schedule to plan the cadence, respond to time-sensitive events like new leads as close to real time as the connection allows, and write every outbound touch back as an Activity. The general version of this read-plan-act-log loop applies across every AMS and is covered in the [AMS + AI integration guide](/resources/ams-ai-integration-guide).
+
+## Writing Activities Back Is the Whole Game
+
+This is the part agencies underestimate. If the AI sends a renewal email but does not record it in Epic, your producer calls a client who already got the message, the client wonders if anyone there talks to each other, and trust in the system collapses.
+
+Every automated touch has to land in the Activities log: what was sent, to whom, when, and through which channel. Done correctly, a producer opens any client in Epic and sees the AI's outreach sitting right alongside their own notes, in order. The automation becomes an extra team member whose work is fully visible, not a black box running in parallel.
+
+The same rule applies to opt-outs. If a client replies "stop," that preference has to be honored and reflected in Epic immediately, so no other workflow contacts them.
+
+## Realistic Timeline and Failure Modes
+
+Wiring AI to Applied Epic is a two-to-three-week job for a focused build, not an afternoon. The schedule usually looks like this:
+
+- **Week 1:** Confirm data access, map the Epic fields to the workflow, and stand up exports.
+- **Week 2:** Build the renewal cadence in draft mode, where a human approves outreach before it sends, and validate write-back to Activities.
+- **Week 3:** Turn on automatic sending for the early touches, add lead response, and train the team.
+
+The failure modes are predictable. The most common is dirty data: x-dates that are wrong or missing mean the cadence fires at the wrong time, so a data hygiene pass comes first. The second is skipping write-back to save time, which always costs more later. The third is going fully automatic before the drafts have earned trust. Onboard the AI the way you would onboard a CSR, supervised at first, then loosened as it proves out.
+
+If your team wants to build this in-house, the [Agency Operations Bootcamp](/courses/ai-agency-ops-bootcamp) walks through the Epic-specific setup. If you would rather have it built and run for you, [book a free renewal audit](/#pricing) and we will map it against your actual Epic data before you commit to anything.
+
+Applied Epic gives you the cleanest foundation in the independent space. The agencies that win with it are the ones that treat the Activities log as sacred and let the AI keep it complete.

--- a/content/resources/ezlynx-ai-automation.md
+++ b/content/resources/ezlynx-ai-automation.md
@@ -1,0 +1,70 @@
+---
+title: "EZLynx AI Automation: Renewals, Leads, and Quote Follow-Up"
+slug: "ezlynx-ai-automation"
+description: "What AI automation looks like on EZLynx: pulling policy and rating data, automating renewal and quote follow-up, and writing activity back to the client record."
+publishedAt: "2026-05-31"
+category: "Integrations"
+primaryKeyword: "EZLynx AI automation"
+readTime: 9
+related:
+  - "ai-for-insurance-agencies-guide"
+  - "ams-ai-integration-guide"
+  - "ai-renewal-automation-playbook"
+---
+
+# EZLynx AI Automation: Renewals, Leads, and Quote Follow-Up
+
+EZLynx is the rater-plus-management platform that a huge number of personal lines agencies run their day on. Its native comparative rater is used by roughly 38,000 agencies, and by agency count it powers an estimated 22% of independent agencies with fewer than 10 employees ([2026 AMS market data](https://www.quotesweep.com/blog/ams-comparison-2026)). Since 2021 it has been part of Applied Systems ([Applied Systems](https://www1.appliedsystems.com/en-us/news/press-releases/2021/applied-systems-completes-acquisition-of-ezlynx/)). That combination of management system plus built-in rating is exactly why EZLynx shops have an AI advantage most agencies do not: the data to re-shop a renewal is already in the building.
+
+This guide covers what you can automate on EZLynx, how the integration works, and the rating-engine edge worth leaning into.
+
+## Where Your Data Lives in EZLynx
+
+EZLynx keeps the applicant, the policy, and the quote close together:
+
+- **Applicants and clients.** Contact records, household data, and communication preferences.
+- **Policy data.** Coverage and expiration detail, much of it flowing from the rating engine and carrier connections.
+- **Activities and notes.** The interaction history where automated outreach is written back.
+- **Automation Center and Communication Center.** EZLynx's native automation and messaging tooling, which the AI layer complements rather than replaces.
+
+## What You Can Automate on EZLynx
+
+| Workflow | What EZLynx provides | What the AI does |
+|----------|----------------------|------------------|
+| Renewal outreach | Expiration dates, policy and rating data | Runs the 60/30/14/7-day cadence, flags rate-shock renewals |
+| Rate-shopping at renewal | Native comparative rater | Surfaces renewals worth re-marketing before the client shops |
+| Instant lead response | New applicant entries | Replies in under 60 seconds, logs an activity |
+| Quote follow-up | Quote and applicant records | Multi-touch sequence until the prospect binds or declines |
+
+Renewals plus rate-shopping is the combination that earns its keep on EZLynx. Start with the cadence from our [renewal automation playbook](/resources/ai-renewal-automation-playbook), then add the rater step below.
+
+## How the Integration Works
+
+Two channels, used together:
+
+1. **The EZLynx API.** Where available, it allows reads of applicant and policy data and write-back of activities to the client record.
+2. **Reporting exports.** Scheduled extracts of the renewal window are the dependable backbone for planning the cadence, with the API handling time-sensitive events like a new lead.
+
+It is the same read-plan-act-log loop covered in the [AMS + AI integration guide](/resources/ams-ai-integration-guide). On a different system? See the companion guides for [Applied Epic](/resources/applied-epic-ai-automation) and [HawkSoft](/resources/hawksoft-ai-automation).
+
+One EZLynx-specific note: mind the applicant-versus-client-versus-household structure. Pulling "clients" without understanding the hierarchy is the most common way an EZLynx integration sends the wrong message to the wrong record.
+
+## Lean Into the Rater
+
+This is the EZLynx advantage. On most platforms, re-shopping a renewal means exporting data into a separate rater. On EZLynx the rater is right there. That means the AI can do something genuinely valuable at renewal: flag the policies where the carrier's renewal increase is steep enough that a re-market is likely to save the client money, and tee that up for a producer before the client goes shopping on their own.
+
+The result is a renewal motion that does not just defend the book, it actively keeps clients from leaving over a rate bump, which is the single most common reason a personal lines policy walks. Every automated touch still gets written back as an activity, so the producer sees the full history on the client record.
+
+## Timeline and Failure Modes
+
+A focused EZLynx build runs two to three weeks:
+
+- **Week 1:** Confirm data access, map the applicant and policy structure, and stand up exports.
+- **Week 2:** Build the renewal cadence in draft mode and validate activity write-back.
+- **Week 3:** Add the rate-shopping flag and lead response, loosen to automatic sending, and train the team.
+
+The failure modes: misreading the applicant hierarchy, skipping activity write-back, and going fully automatic before the drafts are trustworthy. Clean the contact data first, supervise early, and expand as it proves out.
+
+If your team wants to build it in-house, the [Agency Operations Bootcamp](/courses/ai-agency-ops-bootcamp) walks through the EZLynx setup. If you would rather have it built and run for you, [book a free renewal audit](/#pricing) and we will map it against your actual EZLynx data first.
+
+EZLynx already gives you the rater and the management system in one place. AI automation is what finally puts them to work together on every renewal, not just the ones a producer has time to re-shop.

--- a/content/resources/hawksoft-ai-automation.md
+++ b/content/resources/hawksoft-ai-automation.md
@@ -1,0 +1,71 @@
+---
+title: "HawkSoft AI Automation: A Practical Guide for Independent Agencies"
+slug: "hawksoft-ai-automation"
+description: "How to layer AI renewal, lead-response, and quote follow-up automation on HawkSoft CMS using the API and exports, with opt-out enforcement and clean write-back."
+publishedAt: "2026-05-31"
+category: "Integrations"
+primaryKeyword: "HawkSoft AI automation"
+readTime: 9
+related:
+  - "ai-for-insurance-agencies-guide"
+  - "ams-ai-integration-guide"
+  - "ai-renewal-automation-playbook"
+---
+
+# HawkSoft AI Automation: A Practical Guide for Independent Agencies
+
+HawkSoft built its reputation on service. It is the AMS of choice for a big slice of smaller, relationship-driven agencies: by agency count it runs an estimated 18% of independent agencies with fewer than 10 employees ([2026 AMS market data](https://www.quotesweep.com/blog/ams-comparison-2026)). That profile is exactly the kind of shop that benefits most from AI automation, because the work that protects a relationship-driven book is also the work that gets dropped first when three people are running 1,500 policies.
+
+This guide covers what you can automate on HawkSoft, how the integration works, and the one rule that keeps you out of trouble: never fight the carrier download.
+
+## Where Your Data Lives in HawkSoft
+
+HawkSoft organizes the agency around the client, and the AI reads from four places:
+
+- **Client records.** Contact info, household structure, and the communication preferences that govern consent.
+- **Policies.** Coverage, premium, carrier, and expiration date. Most of this arrives through carrier downloads, which matters a great deal (more below).
+- **Log Notes.** HawkSoft's running history of every client interaction. This is where automated outreach gets written back.
+- **Suspenses.** HawkSoft's task and follow-up reminders. The AI can open a Suspense to put a flagged renewal or a hot lead in front of the right person.
+
+## What You Can Automate on HawkSoft
+
+The high-ROI workflows map cleanly onto HawkSoft's structure.
+
+| Workflow | What HawkSoft provides | What the AI does |
+|----------|------------------------|------------------|
+| Renewal outreach | Expiration dates, policy detail | Runs the 60/30/14/7-day cadence, opens a Suspense for at-risk accounts |
+| Instant lead response | New client / contact entries | Replies in under 60 seconds, logs a Log Note |
+| Quote follow-up | Open quotes, prospect records | Multi-touch sequence until the prospect responds |
+| Service triage | Inbound email | Drafts replies, flags anything that needs a licensed human |
+
+Renewals are the place to start. The full cadence is in our [renewal automation playbook](/resources/ai-renewal-automation-playbook), and HawkSoft's expiration data drives it without a spreadsheet in sight.
+
+## How the Integration Works
+
+Two channels, used together:
+
+1. **The HawkSoft API.** HawkSoft's integration program exposes client, policy, and log data, which is enough to read the renewal window and write outreach back as Log Notes close to real time.
+2. **The export builder.** For full-book pulls, or agencies not yet on the API, HawkSoft's reporting and CSV exports are a reliable fallback. Scheduled exports feed the renewal planner; the API handles time-sensitive events like a new lead.
+
+The pattern is the same read-plan-act-log loop that works on every AMS, covered in the [AMS + AI integration guide](/resources/ams-ai-integration-guide). On a different system? We have companion guides for [Applied Epic](/resources/applied-epic-ai-automation) and [EZLynx](/resources/ezlynx-ai-automation).
+
+## Never Fight the Carrier Download
+
+This is the rule that separates a clean HawkSoft integration from a support headache. Most of your policy data in HawkSoft arrives through carrier downloads. If your automation writes policy data back, the next download overwrites it, the records disagree, and you lose a week untangling it.
+
+So the AI writes to Log Notes and Suspenses, never to policy fields. Outreach history lands in Log Notes, where a CSR opens any client and sees exactly what the system said and when, right next to their own notes. Follow-up that needs a human becomes a Suspense assigned to the right producer. The carrier download stays untouched.
+
+Opt-outs get the same discipline. HawkSoft carries consent at the client level, and the automation checks it on every single send. If a client says stop, every workflow honors it immediately.
+
+## Timeline and Failure Modes
+
+A focused HawkSoft build runs about two weeks:
+
+- **Week 1:** Confirm API or export access, map fields to the renewal workflow, and validate Log Note write-back.
+- **Week 2:** Turn on the renewal cadence in draft mode, add lead response, then loosen to automatic sending as the drafts prove out, and train the team.
+
+The failure modes are familiar. Writing to policy fields instead of Log Notes is the classic HawkSoft mistake. Stale contact data is the second: a book full of old phone numbers means outreach to dead ends, so a quick data hygiene pass comes first. And as always, do not flip everything to fully automatic before the drafts have earned trust.
+
+If your team wants to build this themselves, the [Agency Operations Bootcamp](/courses/ai-agency-ops-bootcamp) covers the setup. If you would rather have it built and run for you, [book a free renewal audit](/#pricing) and we will map it against your actual HawkSoft data first.
+
+HawkSoft shops win on service. AI automation lets a small team deliver that service to every client on the book, not just the ones who happened to call this week.

--- a/docs/GROWTH-PLAN.md
+++ b/docs/GROWTH-PLAN.md
@@ -12,7 +12,9 @@ and gets cited by AI engines (GEO).
 This document supersedes the stale root-level strategy files (`conversion-test-results.md`,
 `offer-funnel-iteration.md`, `scaling-winning-elements.md`, `ops/EXECUTION-BOARD.md`).
 Those reference pre-Next.js `.html` pages and contain fabricated A/B metrics — keep for
-history, but treat this as the source of truth.
+history, but treat this as the source of truth. One caveat: `scaling-winning-elements.md`
+is still wired into the live content generator (see the Housekeeping note in §2), so it
+cannot be deleted until that code is updated.
 
 ---
 
@@ -95,11 +97,16 @@ These are small, mostly-wired changes that stop losing the traffic we already ge
   `chatgpt.com`, `perplexity.ai`, `gemini.google.com`, `claude.ai`, `copilot.microsoft.com`,
   `bing.com/chat` as `ai_referral` (GA4 custom dimension). Log AI-crawler user-agents from
   middleware for a weekly "who's crawling us" report.
-- **Backlog expansion**: grow `_backlog.json` from 12 → 30+ topics (see §5) so the weekly
+- **Backlog expansion**: grow `_backlog.json` from 12 → 30+ topics (see §7) so the weekly
   engine never starves.
 - **Housekeeping**: move the stale `.html`-era docs into `docs/archive/` so they stop
-  contaminating the content engine's prompt context (the engine reads
-  `scaling-winning-elements.md`).
+  contaminating the content engine's prompt context. ⚠️ Paired code change required: the
+  generator hard-codes `scaling-winning-elements.md` into `buildSystemPrompt()`
+  (`src/lib/content-generation/system-prompt.ts`) as the PROVEN CONVERSION ELEMENTS block.
+  Moving that file without repointing the generator makes the prompt fall back to
+  "(scaling doc not found)" and silently lose all conversion guidance — so relocate the doc
+  **and** point the generator at its replacement (this plan, or a dedicated
+  conversion-elements file) in the same commit.
 
 ---
 
@@ -265,7 +272,7 @@ quote and competitors link to. This single asset can do more for GEO than 20 art
 | 2 | `/signup` + `/api/auth/signup` + `trialEndsAt` migration | P4 pillar: *AI for Insurance Agencies* | `sameAs` expansion; G2/Capterra listings |
 | 3 | Demo-data auto-seed + guided first-run | `/for/applied-epic` | Per-article FAQ schema live |
 | 4 | Trial gating + upgrade→Stripe + book-a-call→Calendly; lifecycle emails | `/for/hawksoft`, `/for/ezlynx` | Lesson JSON-LD; OG images |
-| 5 | "Start free trial" CTA across site; pricing experiment | `/compare/...-vs-gohighlevel` | CWV pass on hero |
+| 5 | "Start free trial" CTA across site; pricing experiment | `/compare/renewalengineai-vs-gohighlevel` | CWV pass on hero |
 | 6 | Trial analytics dashboard | `/tools/roi-calculator` standalone | `llms-full.txt`; auto-update llms.txt |
 | 7 | First CRO A/B (CTA primacy) | Solution page: renewal-automation | Internal-link/related rollout |
 | 8 | Iterate trial activation | Solution page: lead-response | Programmatic comparison metadata |

--- a/docs/GROWTH-PLAN.md
+++ b/docs/GROWTH-PLAN.md
@@ -1,0 +1,307 @@
+# RenewalEngineAI — Content, GEO & SCO Growth Plan
+
+**Goal:** Turn the site into a two-path conversion engine where a visitor can either
+(a) **start a free self-serve trial of the product**, or (b) **book the Calendly "Free
+Renewal Audit"** — and feed both paths with content that ranks (SEO), converts (CRO),
+and gets cited by AI engines (GEO).
+
+> Scope decisions (confirmed with owner): "the product" = a **new self-serve SaaS trial**
+> of the renewals dashboard (does not exist yet — this plan includes building it).
+> "SCO" = **SEO + CRO** (rank *and* convert).
+
+This document supersedes the stale root-level strategy files (`conversion-test-results.md`,
+`offer-funnel-iteration.md`, `scaling-winning-elements.md`, `ops/EXECUTION-BOARD.md`).
+Those reference pre-Next.js `.html` pages and contain fabricated A/B metrics — keep for
+history, but treat this as the source of truth.
+
+---
+
+## 0. Where we are today (audit)
+
+**Strong foundations already shipped:**
+- Next.js App Router marketing site + provisioned-only dashboard (renewals tracking + AI
+  renewal-email generation), Stripe checkout, NextAuth, Prisma/Neon.
+- Mature SEO/GEO scaffolding: `Organization`/`WebSite`/`Person`/`Service` `@graph`
+  (`src/app/layout.tsx`), dynamic `sitemap.ts`, `robots.ts` with a full AI-crawler
+  allowlist (GPTBot, ClaudeBot, PerplexityBot, Google-Extended…), comprehensive `llms.txt`,
+  per-page canonicals, OpenGraph/Twitter.
+- Per-page-type schema is **already good**: resources/comparisons/case-studies emit
+  `Article` + `SpeakableSpecification` + `BreadcrumbList`; courses emit
+  `Course`/`Offer`/`CourseInstance`; home emits `FAQPage`.
+- Automated content engine: weekly GitHub Action (`.github/workflows/weekly-content.yml`)
+  drafts a long-form resource from `content/resources/_backlog.json` (12 pending topics)
+  with enforced house voice, internal links, and a subtle CTA (`src/lib/content-generation/*`).
+- Content inventory: 3 resources, 3 comparisons, 2 case studies, 2 courses (28 lessons),
+  2 lead magnets, Mastermind + Team Licenses.
+
+**Conversion gaps / leaks (the important part):**
+| # | Gap | Evidence | Impact |
+|---|-----|----------|--------|
+| L1 | **Homepage lead magnet is broken** — POSTs to `/api/lead-magnet`, which doesn't exist (the `LeadMagnetSubscriber` model exists, the route doesn't). | `src/components/marketing/LeadMagnet.tsx:19` vs `src/app/api` | Every homepage email capture 404s. Top-of-funnel leak. |
+| L2 | **No self-serve product signup/trial.** `/login` has no "Sign up"; accounts are only created by the Stripe webhook (post-purchase set-password). | `src/app/login/page.tsx`, `src/app/api/stripe/webhook/route.ts` | The "product" conversion path the owner wants does not exist. |
+| L3 | **Content pages lack a strong conversion block.** Resource/comparison/case-study bodies have only a subtle inline text link; the dual-CTA `AuditTripwire` is used on just 2 pages. | `src/components/resources/ResourceBody.tsx`, `AuditTripwire` usage | Article readers (the GEO/SEO traffic) have no clear next step. |
+| L4 | **Cold traffic sent straight to $6,000 / $2,500-mo Stripe checkout** from homepage pricing. | `src/components/marketing/Pricing.tsx:81` | High-friction; no low-commitment entry. |
+| L5 | **No AI-referral / GEO measurement.** GA4 + Humblytics exist but nothing parses chatgpt.com / perplexity.ai / gemini referrers or AI-crawler hits. | `src/app/layout.tsx`, `src/lib/analytics.ts` | Can't prove or tune GEO. |
+| L6 | Lessons have canonicals but **no JSON-LD**; no per-article `FAQPage`; no `Review`/`AggregateRating`; `sameAs` is LinkedIn-only. | lesson page; resources `[slug]` | Missed GEO/rich-result surface area. |
+
+---
+
+## 1. Target conversion architecture (the spine of everything)
+
+Two parallel paths, mapped to buyer intent — **presented side by side, never competing:**
+
+```
+                         ┌─────────────────────────────────────────┐
+   SEO / GEO / Social ──▶ │  Content (resources, comparisons, AMS,   │
+   (top of funnel)        │  case studies, glossary, calculators)    │
+                         └───────────────┬─────────────┬─────────────┘
+                                         │             │
+                  "Try it yourself, free"│             │"Have us build & run it"
+                           (low friction)│             │(high touch)
+                                         ▼             ▼
+                              ┌────────────────┐   ┌──────────────────┐
+                              │ SELF-SERVE      │   │ CALENDLY          │
+                              │ TRIAL (new)     │   │ Free Renewal Audit│
+                              │ → dashboard     │   │ → Audit/Build/    │
+                              │ → upgrade $$    │   │   Managed         │
+                              └───────┬────────┘   └──────────────────┘
+                                      │  in-app: "Want us to run this? Book a call" ──▶ (Calendly)
+                                      ▼
+                               Self-serve paid plan (Stripe)
+```
+
+**Rules this plan enforces everywhere:**
+1. Every high-traffic page (home, content, AMS, comparisons) offers **both** CTAs:
+   primary = **Start free trial**, secondary = **Book a free audit**.
+2. Email capture (lead magnet) is the fallback for visitors not ready for either.
+3. The trial is itself a sales channel: in-app prompts route high-touch users to Calendly
+   (PLG → sales-assist).
+
+**Primary KPIs:** trial signups, trial→paid, Calendly bookings, booking→close.
+**Leading indicators:** organic sessions, AI-referral sessions, lead-magnet subs, activation rate (first AI draft generated).
+
+---
+
+## 2. Phase 1 — Fix the leaks (Week 1, fast + high ROI)
+
+These are small, mostly-wired changes that stop losing the traffic we already get.
+
+- **L1 — Build `POST /api/lead-magnet`**: write to the existing `LeadMagnetSubscriber`
+  model, send the playbook via `src/lib/email.ts`, fire a `lead_capture` GA event. ~1 file.
+- **L3 — Ship a shared `<ContentCTA />`** (generalize `AuditTripwire`): two buttons
+  ("Start free trial" + "Book a free audit") + email-capture fallback. Render it at the
+  bottom of every resource/comparison/case-study and inside `ResourceBody` after the body.
+- **L5 — AI-referral tracking**: in `src/lib/analytics.ts`, tag sessions whose referrer is
+  `chatgpt.com`, `perplexity.ai`, `gemini.google.com`, `claude.ai`, `copilot.microsoft.com`,
+  `bing.com/chat` as `ai_referral` (GA4 custom dimension). Log AI-crawler user-agents from
+  middleware for a weekly "who's crawling us" report.
+- **Backlog expansion**: grow `_backlog.json` from 12 → 30+ topics (see §5) so the weekly
+  engine never starves.
+- **Housekeeping**: move the stale `.html`-era docs into `docs/archive/` so they stop
+  contaminating the content engine's prompt context (the engine reads
+  `scaling-winning-elements.md`).
+
+---
+
+## 3. Phase 2 — Self-serve product trial (PLG) — Weeks 2–4
+
+The net-new "product signup" path. The data model is already 80% ready:
+`SubscriptionStatus.TRIALING` exists, the demo-seed script exists, AI draft generation works.
+
+### 3.1 Signup + trial flow
+- **New `/signup` page** + **`POST /api/auth/signup`**: create `Organization` +
+  `User` (hashed password or magic-link), set `subscriptionStatus = TRIALING`. Add a
+  `trialEndsAt DateTime?` column to `Organization` (migration) → default 14 days.
+- Add **"Start free trial"** to `/login`, the header, hero, pricing, and `<ContentCTA />`.
+- Reuse the existing Stripe webhook provisioning logic; factor account creation into a
+  shared `provisionOrg()` so signup and purchase share one path.
+
+### 3.2 Activation = the "magic moment"
+- On signup, **auto-seed demo policies** (promote `scripts/seed-renewals-demo.ts` to a
+  `seedDemoData(orgId)` lib function). The dashboard is never empty.
+- Guided first-run: **(1)** see 12 renewals → **(2)** click "Generate AI renewal email" →
+  **(3)** read a drafted email in the agency's voice → **(4)** connect Gmail/Outlook (OAuth
+  already supported) → **(5)** import your own CSV.
+  Activation metric = **first AI draft generated** within session 1.
+
+### 3.3 Trial gating + conversion
+- Trial limits: cap real sends (demo mode drafts freely, sending requires connect/upgrade);
+  show days-left + upgrade banner.
+- Two in-app conversion routes: **Upgrade** → Stripe self-serve plan; **"Have us run it"**
+  → Calendly. Lifecycle emails on day 1 / 3 / 7 / 11 / 14.
+
+### 3.4 Open decision (owner): self-serve price point
+Tiers today are service-only (`AUDIT`/`SPRINT`/`MANAGED`). A self-serve trial needs a
+self-serve subscription to convert into. The archived `ARR_SPRINT.md` floated
+Starter $299 / Growth $799 / Pro $1,999. **Recommendation:** launch one simple
+self-serve **Starter** plan (e.g., $299–$499/mo, policy-count tiered) and keep
+done-for-you (Build/Managed) as the upsell. *Needs your pricing call before §3.3 build.*
+
+---
+
+## 4. Phase 3 — Content engine: pillar/cluster model
+
+Move from "ad-hoc articles" to a **hub-and-spoke topical authority** structure. Five pillars,
+each = one comprehensive pillar page + 6–10 interlinked cluster articles, all cross-linked
+and pointing at the two conversion paths.
+
+| Pillar | Pillar page | Why | Primary conversion |
+|--------|-------------|-----|--------------------|
+| **P1 Renewal retention & automation** | `/resources/ai-renewal-automation-playbook` (exists, expand) | Core money keyword | Trial + Calendly |
+| **P2 Instant lead response** | `/resources/instant-lead-response-under-60-seconds` (exists) | High-intent, strong stats | Trial + Calendly |
+| **P3 AMS integration** (Applied Epic / HawkSoft / EZLynx) | `/resources/ams-ai-integration-guide` (exists) + **new `/for/applied-epic`, `/for/hawksoft`, `/for/ezlynx`** | Low-competition, very high intent | Trial |
+| **P4 AI for insurance agencies** (category education) | **new** `/resources/ai-for-insurance-agencies` | GEO goldmine — broad "what is" queries AI engines answer | Email + Trial |
+| **P5 Agency economics & ops** (CSR vs AI, ROI, rollout) | `/compare/renewalengineai-vs-hiring-csr` (exists) | Decision-stage, buyer math | Calendly |
+
+### New content **types** to add (surface area for SEO + GEO + conversion)
+1. **AMS landing pages** `/for/{applied-epic|hawksoft|ezlynx}` — integration details +
+   FAQ schema + `SoftwareApplication`/`HowTo`. Highest-intent, lowest-competition.
+2. **Comparison expansion** — the FAQ already names GoHighLevel; build
+   `/compare/renewalengineai-vs-gohighlevel`, `…-vs-an-internal-build`, plus any competitor
+   prospects mention. Comparison pages win "vs" and "alternative" searches *and* AI answers.
+3. **Solution pages** `/solutions/{renewal-automation|lead-response|quote-follow-up|cross-sell}`
+   — today these are homepage sections only; break out as indexable pages.
+4. **Glossary** `/glossary/{term}` — clean definitions ("X-date", "book of business",
+   "lapse rate", "instant lead response"). AI engines love and cite crisp definitions.
+5. **Interactive tools** `/tools/roi-calculator`, `/tools/retention-calculator` — promote the
+   existing `ROICalculator` component to standalone indexable pages. Tools earn backlinks +
+   convert (gate the emailed report → trial).
+6. **Original benchmark report** — "2026 Insurance Lead Response & Retention Benchmark."
+   Original data is the single highest-leverage GEO + link-building asset (see §5.3).
+
+### Cadence
+- **Weekly (automated):** 1 resource article (existing engine; expanded backlog).
+- **Bi-weekly (assisted):** 1 AMS page **or** 1 comparison **or** 1 solution page.
+- **Monthly:** 1 case study + refresh of the worst-performing top-10 page.
+- **Quarterly:** refresh pillar pages; re-publish benchmark with fresh data.
+
+### Engine upgrades (`src/lib/content-generation/*`)
+- Teach it to also draft **comparison** and **AMS** page types (new templates/system prompts).
+- Add `faqs:` to article frontmatter → render `FAQPage` schema per article (see §5).
+- Auto-regenerate `llms.txt` when new content ships (currently static).
+- Keep prompt-caching discipline (system prompt already cache-stable).
+
+A concrete **12-week editorial calendar** lives in §7.
+
+---
+
+## 5. GEO — Generative Engine Optimization
+
+We already have the table stakes (llms.txt, crawler allowlist, Article/FAQ/Speakable schema).
+This is how we get **cited and recommended** by ChatGPT, Perplexity, Gemini, Claude, AI Overviews.
+
+### 5.1 On-page (in the content engine)
+- **Answer-first**: every article and every H2 opens with a 40–60 word, self-contained,
+  extractable answer before elaborating. Tighten the engine's "scannable answer" rule into a
+  hard "definition-style lead sentence" rule.
+- **Question-shaped H2s** matching real prompts ("How fast can AI respond to insurance leads?").
+- **Cited statistics**: every stat (391%, 78%, 15–20%) gets a named source + outbound link.
+  AI engines prefer and re-cite sourced claims.
+- **Machine-readable structure**: ≥1 comparison table or numbered list per article (already required).
+- **Per-article `FAQPage` schema** via frontmatter `faqs:` (extend `resources.ts`,
+  `system-prompt.ts`, and the `[slug]` page). FAQ schema is the most-cited format in AI answers.
+- **`llms.txt` + add `llms-full.txt`** (full-content dump) and auto-update on publish.
+
+### 5.2 Entity & off-site (where GEO is actually won)
+- **Expand `Organization.sameAs`** beyond LinkedIn: Crunchbase, G2, Capterra, Clutch,
+  Twitter/X, YouTube, founder LinkedIn. A consistent entity footprint builds the trust graph
+  AI engines lean on.
+- **Get listed & reviewed**: G2 + Capterra ("AI insurance agency software" categories),
+  insurance software directories, Product Hunt. Reviews → `AggregateRating` schema → citations.
+- **Get mentioned**: targeted presence in `/r/InsuranceAgent`, NetVU / Applied user
+  communities, agency Facebook groups, IA-focused newsletters/podcasts, 2–3 guest posts on
+  insurtech blogs. AI answers heavily weight third-party corroboration, not just your site.
+
+### 5.3 Be the source (highest leverage)
+Publish the **original benchmark report** (§4 type 6). Original numbers ("median insurance
+lead-response time is X; agencies under 1 min convert Y% more") become the thing AI engines
+quote and competitors link to. This single asset can do more for GEO than 20 articles.
+
+### 5.4 Measure GEO
+- AI-referral GA4 dimension (§2 L5) + monthly **manual citation audit**: run a fixed prompt
+  set ("best AI tools for insurance renewals", "how fast should an agency respond to leads",
+  "Applied Epic AI automation") across ChatGPT/Perplexity/Gemini/Claude and log whether we're
+  cited. Track citation share over time.
+- Weekly AI-crawler hit report from middleware logs.
+
+---
+
+## 6. SCO — SEO + CRO
+
+### 6.1 SEO (rank)
+- **Keyword/topic map** per pillar — pair commercial-intent ("insurance renewal automation
+  software", "{AMS} AI automation", "AI for insurance agents") with informational queries the
+  clusters answer. The `llms.txt` "Target Keywords" block is a good seed list.
+- **Technical fixes**:
+  - Add JSON-LD to **lesson pages** (`LearningResource`/`Course` part-of).
+  - Per-page **OG images** (extend `opengraph-image.tsx` per section) for better social/AI cards.
+  - **Core Web Vitals**: the hero uses multiple large blurred gradients + `animate-pulse` —
+    audit LCP/CLS on mobile; lazy/`content-visibility` the heavy decorative layers.
+  - **Programmatic** AMS + comparison pages from a small data file → consistent metadata,
+    schema, internal links at scale.
+- **Internal linking**: resources already render `related`; extend related + breadcrumb +
+  "part of pillar" links to comparisons/case-studies/solutions. Every cluster links up to its
+  pillar and sideways to 2–3 siblings.
+
+### 6.2 CRO (convert)
+- Fix L1 (lead magnet) and ship `<ContentCTA />` (L3) — biggest immediate wins.
+- **Dual-CTA everywhere** once the trial exists: "Start free trial" (primary) + "Book a free
+  audit" (secondary). Today the site is Calendly-only on most CTAs.
+- **Re-sequence homepage pricing (L4)**: keep Audit→Calendly; gate raw $6k/$2.5k-mo Stripe
+  buttons behind "Start trial" or "Book a call" for cold traffic (run as an experiment).
+- **Real experimentation**: use the installed Humblytics + GA4 for genuine A/B tests
+  (headline, CTA label, trial-vs-audit primacy). Replace the fabricated results in the
+  archived docs with a live experiment log. Primary metric = trial signups + bookings.
+- **Friction reducers**: exit-intent + scroll-depth offers on content pages; keep lead-magnet
+  email-only; social proof near every CTA (add real logos/G2 badge as they land).
+
+---
+
+## 7. 12-week execution roadmap & editorial calendar
+
+| Wk | Conversion / Product | Content shipped | GEO / SEO |
+|----|----------------------|-----------------|-----------|
+| 1 | Fix `/api/lead-magnet`; ship `<ContentCTA/>`; AI-referral tracking | Expand backlog to 30+; archive stale docs | Add `faqs:` schema plumbing |
+| 2 | `/signup` + `/api/auth/signup` + `trialEndsAt` migration | P4 pillar: *AI for Insurance Agencies* | `sameAs` expansion; G2/Capterra listings |
+| 3 | Demo-data auto-seed + guided first-run | `/for/applied-epic` | Per-article FAQ schema live |
+| 4 | Trial gating + upgrade→Stripe + book-a-call→Calendly; lifecycle emails | `/for/hawksoft`, `/for/ezlynx` | Lesson JSON-LD; OG images |
+| 5 | "Start free trial" CTA across site; pricing experiment | `/compare/...-vs-gohighlevel` | CWV pass on hero |
+| 6 | Trial analytics dashboard | `/tools/roi-calculator` standalone | `llms-full.txt`; auto-update llms.txt |
+| 7 | First CRO A/B (CTA primacy) | Solution page: renewal-automation | Internal-link/related rollout |
+| 8 | Iterate trial activation | Solution page: lead-response | Programmatic comparison metadata |
+| 9 | — | **Benchmark report** (data collection + write) | Begin citation-audit baseline |
+| 10 | Sales-assist prompts in trial | Glossary (10 terms) | Off-site mentions / guest posts |
+| 11 | Expansion/upgrade emails | Case study #3 + refresh top-10 page | Review-driven `AggregateRating` |
+| 12 | Review funnel end-to-end; plan next quarter | Pillar refresh | GEO citation-share report |
+
+**Backlog topics to add now** (extends `_backlog.json`): AI for insurance agencies (P4 pillar);
+Applied Epic / HawkSoft / EZLynx AI guides; vs GoHighLevel; vs internal build; renewal email
+templates; lead-response SLA template; X-date strategy; book-of-business health metrics;
+insurance AI compliance checklist; multi-line cross-sell triggers; producer comp in an AI agency;
+"how AI engines pick insurance tools" (meta/GEO).
+
+---
+
+## 8. Measurement & definition of done
+
+**Funnel events (GA4 + server-side via `trackServerEvent`):**
+`page_view → lead_capture → trial_signup → activation(first_ai_draft) → upgrade | calendly_booking`.
+
+**Weekly scoreboard:** organic sessions · AI-referral sessions · AI-crawler hits ·
+lead-magnet subs · trial signups · activation % · trial→paid % · Calendly bookings · close %.
+
+**This plan is "done" when:**
+1. A visitor can self-serve **start a trial** and reach the AI-draft magic moment, **or**
+   **book the audit** — from any major page. ✅ both paths live.
+2. The lead-magnet capture works and is tracked.
+3. Every content page has dual CTAs + per-article FAQ schema.
+4. The pillar/cluster structure + AMS/comparison/solution pages are published and interlinked.
+5. AI-referral + citation tracking is reporting, and the benchmark report is live.
+
+---
+
+### Open decisions for the owner
+1. **Self-serve price point** (§3.4) — needed before building trial→paid upgrade.
+2. **Trial length & limits** (recommend 14 days, sending gated).
+3. **Competitor list** for comparison expansion (who do prospects actually mention?).
+4. Whether to keep raw $6k/$2.5k-mo Stripe buttons on the cold homepage or gate them (§6.2).

--- a/src/app/(marketing)/case-studies/[slug]/page.tsx
+++ b/src/app/(marketing)/case-studies/[slug]/page.tsx
@@ -5,6 +5,7 @@ import { Header } from "@/components/marketing/Header";
 import { Footer } from "@/components/marketing/Footer";
 import { BookingProvider } from "@/components/marketing/BookingContext";
 import { ResourceBody } from "@/components/resources/ResourceBody";
+import { ContentCTA } from "@/components/marketing/ContentCTA";
 import { getCaseStudy, listCaseStudies } from "@/lib/case-studies";
 import { team, personJsonLd, personJsonLdId } from "@/lib/team";
 
@@ -207,26 +208,12 @@ export default async function CaseStudyPage({
               </section>
             )}
 
-            <section className="mt-16 bg-gradient-to-br from-emerald-600/10 to-blue-600/10 border border-emerald-500/30 rounded-2xl p-10">
-              <p className="text-emerald-400 font-bold uppercase tracking-wider text-sm mb-3">
-                Your numbers, not ours
-              </p>
-              <h2 className="text-3xl font-black mb-3">
-                Get a 5-day audit grounded in your agency&rsquo;s actual data
-              </h2>
-              <p className="text-neutral-300 mb-6 leading-relaxed">
-                The audit delivers a roadmap with projected retention lift,
-                cross-sell opportunity value, and ROI specific to your book.
-                $1,500 flat. Fully credited toward Build &amp; Launch if you
-                continue.
-              </p>
-              <Link
-                href="/#pricing"
-                className="inline-block bg-emerald-500 hover:bg-emerald-600 text-white font-black rounded-full px-8 py-4 transition-colors"
-              >
-                Find My Revenue Leaks →
-              </Link>
-            </section>
+            <ContentCTA
+              location="case_study_article"
+              eyebrow="Your numbers, not ours"
+              headline="Get an audit grounded in your real agency data"
+              subcopy="A roadmap with projected retention lift, cross-sell value, and ROI specific to your book. Or start with the free AI playbook."
+            />
           </div>
         </main>
         <Footer />

--- a/src/app/(marketing)/compare/[slug]/page.tsx
+++ b/src/app/(marketing)/compare/[slug]/page.tsx
@@ -5,6 +5,7 @@ import { Header } from "@/components/marketing/Header";
 import { Footer } from "@/components/marketing/Footer";
 import { BookingProvider } from "@/components/marketing/BookingContext";
 import { ResourceBody } from "@/components/resources/ResourceBody";
+import { ContentCTA } from "@/components/marketing/ContentCTA";
 import { getComparison, listComparisons } from "@/lib/comparisons";
 import { team, personJsonLd, personJsonLdId } from "@/lib/team";
 
@@ -191,25 +192,12 @@ export default async function ComparisonPage({
               </section>
             )}
 
-            <section className="mt-16 bg-gradient-to-br from-emerald-600/10 to-blue-600/10 border border-emerald-500/30 rounded-2xl p-10">
-              <p className="text-emerald-400 font-bold uppercase tracking-wider text-sm mb-3">
-                The fastest way to decide
-              </p>
-              <h2 className="text-3xl font-black mb-3">
-                Skip the vendor evaluation. Start with an audit.
-              </h2>
-              <p className="text-neutral-300 mb-6 leading-relaxed">
-                Five days, $1,500, specific to your book. You walk away with
-                numbers you can compare to any option &mdash; ours or any
-                competitor&rsquo;s.
-              </p>
-              <Link
-                href="/#pricing"
-                className="inline-block bg-emerald-500 hover:bg-emerald-600 text-white font-black rounded-full px-8 py-4 transition-colors"
-              >
-                Find My Revenue Leaks →
-              </Link>
-            </section>
+            <ContentCTA
+              location="comparison_article"
+              eyebrow="The fastest way to decide"
+              headline="Skip the vendor evaluation. Start with an audit."
+              subcopy="Five days, specific to your book. You walk away with numbers you can compare to any option on the market. Or grab the playbook and start on your own."
+            />
           </div>
         </main>
         <Footer />

--- a/src/app/(marketing)/resources/[slug]/page.tsx
+++ b/src/app/(marketing)/resources/[slug]/page.tsx
@@ -5,6 +5,7 @@ import { Header } from "@/components/marketing/Header";
 import { Footer } from "@/components/marketing/Footer";
 import { BookingProvider } from "@/components/marketing/BookingContext";
 import { ResourceBody } from "@/components/resources/ResourceBody";
+import { ContentCTA } from "@/components/marketing/ContentCTA";
 import { getResource, listResources } from "@/lib/resources";
 import { team, personJsonLd, personJsonLdId } from "@/lib/team";
 
@@ -217,35 +218,12 @@ export default async function ResourceArticlePage({
               </section>
             )}
 
-            <section className="mt-16 bg-gradient-to-br from-emerald-600/10 to-blue-600/10 border border-emerald-500/30 rounded-2xl p-10">
-              <p className="text-emerald-400 font-bold uppercase tracking-wider text-sm mb-3">
-                Free guide
-              </p>
-              <h2 className="text-3xl font-black mb-3">
-                5 AI Automations Every Insurance Agent Should Set Up This Week
-              </h2>
-              <p className="text-neutral-300 mb-6 leading-relaxed">
-                The five automations we install in the first two weeks of a
-                Build &amp; Launch engagement. Set them up yourself, or use
-                this as the scoping doc for a conversation with us.
-              </p>
-              <Link
-                href="/guides/5-ai-automations"
-                className="inline-block bg-emerald-500 hover:bg-emerald-600 text-white font-black rounded-full px-8 py-4 transition-colors"
-              >
-                Get my free guide →
-              </Link>
-              <p className="text-sm text-neutral-500 mt-6">
-                Ready to talk instead?{" "}
-                <Link
-                  href="/#pricing"
-                  className="text-blue-500 hover:text-blue-400 underline underline-offset-4"
-                >
-                  See audit pricing and packages
-                </Link>
-                .
-              </p>
-            </section>
+            <ContentCTA
+              location="resource_article"
+              eyebrow="Put this to work"
+              headline="Want this built for your agency?"
+              subcopy="Book a free 30-minute renewal audit to see where your book is leaking, or grab the playbook and start on your own this week."
+            />
           </div>
         </main>
         <Footer />

--- a/src/app/api/lead-magnet/route.ts
+++ b/src/app/api/lead-magnet/route.ts
@@ -1,5 +1,6 @@
 import { after, NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
+import { Prisma } from "@prisma/client";
 import { sendLeadMagnetEmail } from "@/lib/email";
 import { logAudit } from "@/lib/audit";
 import { log } from "@/lib/logger";
@@ -34,46 +35,59 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: "invalid_email" }, { status: 400 });
     }
 
-    // Upsert so duplicate submissions return success without creating
-    // duplicate rows or re-spamming the welcome email path.
-    const subscriber = await prisma.leadMagnetSubscriber.upsert({
-      where: { email },
-      create: { email, source },
-      update: {},
-    });
+    // Insert with create + unique-violation catch rather than upsert, so we
+    // can tell a brand-new subscriber from a repeat submission. The DB's
+    // unique(email) constraint is the arbiter, so this stays correct under
+    // concurrent double-clicks without a read-then-write race.
+    let isNew = true;
+    let subscriberId: string | undefined;
+    try {
+      const created = await prisma.leadMagnetSubscriber.create({
+        data: { email, source },
+      });
+      subscriberId = created.id;
+    } catch (err) {
+      if (
+        err instanceof Prisma.PrismaClientKnownRequestError &&
+        err.code === "P2002"
+      ) {
+        isNew = false; // already subscribed — idempotent success, no re-send
+      } else {
+        throw err;
+      }
+    }
 
     await logAudit({
       action: "lead_magnet.subscribed",
       resource: "LeadMagnetSubscriber",
-      resourceId: subscriber.id,
-      metadata: { source },
+      resourceId: subscriberId,
+      metadata: { source, isNew },
     });
 
-    // Capture the GA client id from the request cookie now; it isn't
-    // available once we're inside `after()`.
-    const clientId = readGaClientIdFromCookie(req.headers.get("cookie"));
-
-    // Deliver the playbook and fire the lead event AFTER the response, but
-    // within the request lifetime via `after()` (Vercel keeps the function
-    // alive to finish it). A bare fire-and-forget promise can be frozen or
-    // dropped when the serverless function suspends post-response, and the
-    // playbook email is the whole point of this endpoint. The DB row above
-    // is already committed as the source of truth, so a failed send never
-    // fails the user's submission, and the GA4 event no-ops without env vars.
-    after(async () => {
-      try {
-        await sendLeadMagnetEmail(email);
-      } catch (err) {
-        log.error("[lead-magnet] playbook email failed:", err);
-      }
-      if (clientId) {
-        await trackServerEvent({
-          name: "lead_submit",
-          params: { source },
-          clientId,
-        });
-      }
-    });
+    // Side effects fire for first-time subscribers only. Repeat submissions
+    // (double-click, retries, or anyone re-posting the same address to this
+    // public endpoint) must not re-send the playbook or inflate GA lead
+    // counts. Run them via `after()` so they complete within the request
+    // lifetime instead of as a fire-and-forget promise the serverless
+    // function can drop after responding.
+    if (isNew) {
+      // Capture the GA client id now; it isn't available inside `after()`.
+      const clientId = readGaClientIdFromCookie(req.headers.get("cookie"));
+      after(async () => {
+        try {
+          await sendLeadMagnetEmail(email);
+        } catch (err) {
+          log.error("[lead-magnet] playbook email failed:", err);
+        }
+        if (clientId) {
+          await trackServerEvent({
+            name: "lead_submit",
+            params: { source },
+            clientId,
+          });
+        }
+      });
+    }
 
     return NextResponse.json({ ok: true });
   } catch (err) {

--- a/src/app/api/lead-magnet/route.ts
+++ b/src/app/api/lead-magnet/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from "next/server";
+import { after, NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
 import { sendLeadMagnetEmail } from "@/lib/email";
 import { logAudit } from "@/lib/audit";
@@ -49,22 +49,31 @@ export async function POST(req: NextRequest) {
       metadata: { source },
     });
 
-    // Fire-and-forget playbook delivery. Do not block the response on email
-    // delivery — the DB row is the source of truth.
-    sendLeadMagnetEmail(email).catch((err) => {
-      log.error("[lead-magnet] playbook email failed:", err);
-    });
-
-    // Server-side GA4 lead event for attribution. No-ops when GA env vars
-    // are unset (preview deploys), and when no `_ga` cookie is present.
+    // Capture the GA client id from the request cookie now; it isn't
+    // available once we're inside `after()`.
     const clientId = readGaClientIdFromCookie(req.headers.get("cookie"));
-    if (clientId) {
-      void trackServerEvent({
-        name: "lead_submit",
-        params: { source },
-        clientId,
-      });
-    }
+
+    // Deliver the playbook and fire the lead event AFTER the response, but
+    // within the request lifetime via `after()` (Vercel keeps the function
+    // alive to finish it). A bare fire-and-forget promise can be frozen or
+    // dropped when the serverless function suspends post-response, and the
+    // playbook email is the whole point of this endpoint. The DB row above
+    // is already committed as the source of truth, so a failed send never
+    // fails the user's submission, and the GA4 event no-ops without env vars.
+    after(async () => {
+      try {
+        await sendLeadMagnetEmail(email);
+      } catch (err) {
+        log.error("[lead-magnet] playbook email failed:", err);
+      }
+      if (clientId) {
+        await trackServerEvent({
+          name: "lead_submit",
+          params: { source },
+          clientId,
+        });
+      }
+    });
 
     return NextResponse.json({ ok: true });
   } catch (err) {

--- a/src/app/api/lead-magnet/route.ts
+++ b/src/app/api/lead-magnet/route.ts
@@ -1,0 +1,74 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/db";
+import { sendLeadMagnetEmail } from "@/lib/email";
+import { logAudit } from "@/lib/audit";
+import { log } from "@/lib/logger";
+import { readGaClientIdFromCookie, trackServerEvent } from "@/lib/analytics";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// Basic RFC 5322-lite email check. Good enough to reject obvious junk; the
+// source of truth is the `email` column's uniqueness constraint.
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+// Captures email opt-ins from the homepage lead magnet and the in-content
+// CTA blocks, writes them to `LeadMagnetSubscriber`, and emails the playbook.
+// The matching `LeadMagnetSubscriber` model already existed in the schema —
+// this route is what was missing, so every prior submission 404'd.
+export async function POST(req: NextRequest) {
+  try {
+    const body = (await req.json().catch(() => ({}))) as {
+      email?: unknown;
+      source?: unknown;
+    };
+
+    const email =
+      typeof body.email === "string" ? body.email.trim().toLowerCase() : "";
+    const source =
+      typeof body.source === "string" && body.source.trim()
+        ? body.source.trim().slice(0, 64)
+        : "lead_magnet";
+
+    if (!email || !EMAIL_RE.test(email) || email.length > 254) {
+      return NextResponse.json({ error: "invalid_email" }, { status: 400 });
+    }
+
+    // Upsert so duplicate submissions return success without creating
+    // duplicate rows or re-spamming the welcome email path.
+    const subscriber = await prisma.leadMagnetSubscriber.upsert({
+      where: { email },
+      create: { email, source },
+      update: {},
+    });
+
+    await logAudit({
+      action: "lead_magnet.subscribed",
+      resource: "LeadMagnetSubscriber",
+      resourceId: subscriber.id,
+      metadata: { source },
+    });
+
+    // Fire-and-forget playbook delivery. Do not block the response on email
+    // delivery — the DB row is the source of truth.
+    sendLeadMagnetEmail(email).catch((err) => {
+      log.error("[lead-magnet] playbook email failed:", err);
+    });
+
+    // Server-side GA4 lead event for attribution. No-ops when GA env vars
+    // are unset (preview deploys), and when no `_ga` cookie is present.
+    const clientId = readGaClientIdFromCookie(req.headers.get("cookie"));
+    if (clientId) {
+      void trackServerEvent({
+        name: "lead_submit",
+        params: { source },
+        clientId,
+      });
+    }
+
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    log.error("[lead-magnet] submission failed:", err);
+    return NextResponse.json({ error: "submission_failed" }, { status: 500 });
+  }
+}

--- a/src/app/api/renewals/policies/[id]/route.ts
+++ b/src/app/api/renewals/policies/[id]/route.ts
@@ -2,13 +2,17 @@ import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { prisma, getTenantDb } from "@/lib/db";
 
-export async function PATCH(req: NextRequest, { params }: { params: { id: string } }) {
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
   const session = await auth();
   const orgId = (session as any)?.organizationId;
   if (!orgId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
   const existing = await prisma.policy.findFirst({
-    where: { id: params.id, organizationId: orgId },
+    where: { id, organizationId: orgId },
   });
   if (!existing) return NextResponse.json({ error: "Not found" }, { status: 404 });
 
@@ -17,7 +21,7 @@ export async function PATCH(req: NextRequest, { params }: { params: { id: string
 
   const tenantDb = getTenantDb(orgId);
   const policy = await tenantDb.policy.update({
-    where: { id: params.id },
+    where: { id },
     data: {
       ...(clientName !== undefined && { clientName }),
       ...(clientEmail !== undefined && { clientEmail }),
@@ -33,16 +37,20 @@ export async function PATCH(req: NextRequest, { params }: { params: { id: string
   return NextResponse.json(policy);
 }
 
-export async function DELETE(req: NextRequest, { params }: { params: { id: string } }) {
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
   const session = await auth();
   const orgId = (session as any)?.organizationId;
   if (!orgId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
   const existing = await prisma.policy.findFirst({
-    where: { id: params.id, organizationId: orgId },
+    where: { id, organizationId: orgId },
   });
   if (!existing) return NextResponse.json({ error: "Not found" }, { status: 404 });
 
-  await prisma.policy.delete({ where: { id: params.id } });
+  await prisma.policy.delete({ where: { id } });
   return NextResponse.json({ success: true });
 }

--- a/src/components/marketing/AuditTripwire.tsx
+++ b/src/components/marketing/AuditTripwire.tsx
@@ -80,7 +80,7 @@ export function AuditTripwire() {
             pressure. You leave with notes either way.
           </p>
           <button
-            onClick={openBooking}
+            onClick={() => openBooking("audit_tripwire")}
             className="bg-white text-black hover:bg-neutral-100 font-black text-lg rounded-full px-6 py-4 transition-all flex items-center justify-center gap-2"
           >
             Book My Free Call

--- a/src/components/marketing/ContentCTA.tsx
+++ b/src/components/marketing/ContentCTA.tsx
@@ -2,7 +2,6 @@
 import { useState } from "react";
 import { ArrowRight, Calendar, CheckCircle } from "lucide-react";
 import { useBooking } from "@/components/marketing/BookingContext";
-import { trackEvent } from "@/lib/analytics";
 
 interface ContentCTAProps {
   /** Analytics label — flows into `book_audit_click` / `lead_submit` events. */
@@ -60,7 +59,9 @@ export function ContentCTA({
         setStatus("error");
         return;
       }
-      trackEvent("lead_submit", { source: location });
+      // The /api/lead-magnet route fires the GA4 `lead_submit` event
+      // server-side (single source of truth), so we don't fire it here too
+      // and double-count the conversion.
       setStatus("done");
     } catch {
       setError("Something went wrong. Please try again.");

--- a/src/components/marketing/ContentCTA.tsx
+++ b/src/components/marketing/ContentCTA.tsx
@@ -1,0 +1,159 @@
+"use client";
+import { useState } from "react";
+import { ArrowRight, Calendar, CheckCircle } from "lucide-react";
+import { useBooking } from "@/components/marketing/BookingContext";
+import { trackEvent } from "@/lib/analytics";
+
+interface ContentCTAProps {
+  /** Analytics label — flows into `book_audit_click` / `lead_submit` events. */
+  location: string;
+  eyebrow?: string;
+  headline?: string;
+  subcopy?: string;
+}
+
+/**
+ * Conversion block rendered at the foot of every content article
+ * (resources, comparisons, case studies). Gives article readers two
+ * explicit next steps instead of a single static link to /#pricing:
+ *
+ *   A. Book a free renewal audit (high-touch)  -> opens the Calendly modal
+ *   B. Grab the AI playbook (low friction)      -> POST /api/lead-magnet
+ *
+ * `openBooking` already fires `book_audit_click`, so path A doesn't
+ * double-track. Path B captures the email the homepage magnet was losing.
+ *
+ * Phase 2 seam: when the self-serve trial ships, add a third
+ * "Start free trial" button here pointing at /signup.
+ */
+export function ContentCTA({
+  location,
+  eyebrow = "Two ways to start",
+  headline = "See exactly where your agency is leaking revenue",
+  subcopy = "Book a free 30-minute renewal audit, or grab the AI playbook and start on your own this week.",
+}: ContentCTAProps) {
+  const { openBooking } = useBooking();
+  const [email, setEmail] = useState("");
+  const [status, setStatus] = useState<"idle" | "loading" | "done" | "error">(
+    "idle"
+  );
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!email.trim() || status === "loading") return;
+    setStatus("loading");
+    setError(null);
+    try {
+      const res = await fetch("/api/lead-magnet", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: email.trim(), source: location }),
+      });
+      if (!res.ok) {
+        const data = (await res.json().catch(() => ({}))) as { error?: string };
+        setError(
+          data.error === "invalid_email"
+            ? "Enter a valid email address."
+            : "Something went wrong. Please try again."
+        );
+        setStatus("error");
+        return;
+      }
+      trackEvent("lead_submit", { source: location });
+      setStatus("done");
+    } catch {
+      setError("Something went wrong. Please try again.");
+      setStatus("error");
+    }
+  }
+
+  return (
+    <section className="mt-16 bg-gradient-to-br from-emerald-600/10 to-blue-600/10 border border-emerald-500/30 rounded-2xl p-8 lg:p-10">
+      <p className="text-emerald-400 font-bold uppercase tracking-wider text-sm mb-3">
+        {eyebrow}
+      </p>
+      <h2 className="text-3xl font-black text-white mb-3">{headline}</h2>
+      <p className="text-neutral-300 mb-8 leading-relaxed max-w-2xl">{subcopy}</p>
+
+      <div className="grid md:grid-cols-2 gap-4">
+        {/* Path A — Book the audit (high-touch) */}
+        <div className="bg-neutral-900/70 border border-neutral-800 rounded-2xl p-6 flex flex-col">
+          <div className="flex items-center gap-2 mb-3 text-neutral-400">
+            <Calendar className="h-5 w-5 text-blue-400" />
+            <span className="text-xs uppercase tracking-wider font-bold">
+              Have us do it
+            </span>
+          </div>
+          <p className="text-white font-bold text-lg mb-4 flex-1">
+            Free 30-min renewal audit — we find your top 3 revenue leaks, live.
+          </p>
+          <button
+            onClick={() => openBooking(location)}
+            className="bg-emerald-500 hover:bg-emerald-600 text-white font-black rounded-full px-6 py-3.5 transition-colors flex items-center justify-center gap-2"
+          >
+            Book my free audit
+            <ArrowRight className="h-5 w-5" />
+          </button>
+        </div>
+
+        {/* Path B — Self-serve playbook (low friction) */}
+        <div className="bg-neutral-900/70 border border-neutral-800 rounded-2xl p-6 flex flex-col">
+          <div className="flex items-center gap-2 mb-3 text-neutral-400">
+            <CheckCircle className="h-5 w-5 text-emerald-400" />
+            <span className="text-xs uppercase tracking-wider font-bold">
+              Start on your own
+            </span>
+          </div>
+          {status === "done" ? (
+            <p className="text-white font-bold text-lg flex-1 flex items-center">
+              Check your inbox — the AI playbook is on its way.
+            </p>
+          ) : (
+            <>
+              <p className="text-white font-bold text-lg mb-4 flex-1">
+                Get the free AI playbook: the 5 automations to set up this week.
+              </p>
+              <form
+                onSubmit={handleSubmit}
+                className="flex flex-col sm:flex-row gap-2"
+              >
+                <input
+                  type="email"
+                  required
+                  placeholder="you@agency.com"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  className="flex-1 bg-white/5 border border-neutral-700 text-white placeholder:text-neutral-500 px-4 py-3 rounded-full focus:outline-none focus:ring-2 focus:ring-emerald-500"
+                />
+                <button
+                  type="submit"
+                  disabled={status === "loading"}
+                  className="bg-white text-black hover:bg-neutral-100 disabled:opacity-60 font-black rounded-full px-6 py-3 whitespace-nowrap transition-colors"
+                >
+                  {status === "loading" ? "Sending…" : "Get it"}
+                </button>
+              </form>
+              {error && (
+                <p role="alert" className="text-red-400 text-sm mt-2">
+                  {error}
+                </p>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+
+      <p className="text-sm text-neutral-500 mt-6">
+        Prefer to compare packages first?{" "}
+        <a
+          href="/#pricing"
+          className="text-blue-500 hover:text-blue-400 underline underline-offset-4"
+        >
+          See audit pricing
+        </a>
+        .
+      </p>
+    </section>
+  );
+}

--- a/src/components/marketing/Header.tsx
+++ b/src/components/marketing/Header.tsx
@@ -44,7 +44,7 @@ export function Header() {
           {/* Mobile: CTA visible in top bar + hamburger */}
           <div className="flex md:hidden items-center gap-2">
             <Button
-              onClick={openBooking}
+              onClick={() => openBooking("header_mobile_topbar")}
               className="bg-blue-600 hover:bg-blue-700 !text-white font-bold rounded-full px-4 py-2 text-sm"
             >
               Free Audit

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -22,7 +22,8 @@ export type AuditAction =
   | "user.password_reset"
   | "data.exported"
   | "data.deleted"
-  | "mastermind_invite.submitted";
+  | "mastermind_invite.submitted"
+  | "lead_magnet.subscribed";
 
 export async function logAudit(params: {
   organizationId?: string;

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -3,6 +3,8 @@ import { log } from "@/lib/logger";
 const RESEND_API_KEY = process.env.RESEND_API_KEY || "";
 const FROM_EMAIL = process.env.FROM_EMAIL || "RenewalEngineAI <noreply@renewalengineai.com>";
 const APP_URL = process.env.NEXTAUTH_URL || "https://renewalengineai.com";
+const CALENDLY_AUDIT_URL =
+  process.env.CALENDLY_AUDIT_URL || "https://calendly.com/joshrkay-ch88/30min";
 
 interface SendEmailParams {
   to: string;
@@ -193,6 +195,61 @@ export async function sendTokenExpiryWarning(
 
         <hr style="border: none; border-top: 1px solid #e5e5e5; margin: 32px 0;" />
         <p style="color: #a3a3a3; font-size: 12px;">RenewalEngineAI — AI Automation for Insurance Agencies</p>
+      </div>
+    `,
+  });
+}
+
+// Delivers the lead-magnet "playbook" after a homepage / in-content email
+// opt-in. Links to the on-site guide and offers the free audit as the
+// natural next step (the email itself is a conversion surface).
+export async function sendLeadMagnetEmail(email: string): Promise<void> {
+  const guideUrl = `${APP_URL}/guides/5-ai-automations`;
+
+  await sendEmail({
+    to: email,
+    subject: "Your AI Insurance Agency Playbook (5 automations inside)",
+    html: `
+      <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 600px; margin: 0 auto; padding: 40px 20px;">
+        <div style="text-align: center; margin-bottom: 32px;">
+          <h1 style="color: #4f46e5; font-size: 24px; margin: 0;">RenewalEngineAI</h1>
+        </div>
+
+        <h2 style="color: #0a0a0a; font-size: 20px;">Here is your playbook</h2>
+
+        <p style="color: #525252; font-size: 16px; line-height: 1.6;">
+          Thanks for grabbing the Insurance Agency AI Playbook. It walks through the
+          five automations we install in the first two weeks of a Build &amp; Launch:
+          renewal outreach, instant lead response, quote follow-up, cross-sell triggers,
+          and after-hours capture. Most agencies spot 3-5 revenue leaks on the first read.
+        </p>
+
+        <div style="text-align: center; margin: 32px 0;">
+          <a href="${guideUrl}"
+             style="display: inline-block; background: #10b981; color: white; padding: 14px 32px;
+                    border-radius: 9999px; text-decoration: none; font-weight: bold; font-size: 16px;">
+            Read the Playbook
+          </a>
+        </div>
+
+        <p style="color: #525252; font-size: 16px; line-height: 1.6;">
+          Want us to find the leaks on <strong>your</strong> book instead? Book a free
+          30-minute renewal audit and we will pinpoint your top three in dollars.
+        </p>
+
+        <div style="text-align: center; margin: 24px 0;">
+          <a href="${CALENDLY_AUDIT_URL}"
+             style="display: inline-block; background: #4f46e5; color: white; padding: 12px 28px;
+                    border-radius: 9999px; text-decoration: none; font-weight: bold; font-size: 15px;">
+            Book My Free Audit
+          </a>
+        </div>
+
+        <hr style="border: none; border-top: 1px solid #e5e5e5; margin: 32px 0;" />
+        <p style="color: #a3a3a3; font-size: 12px;">
+          RenewalEngineAI — AI Automation for Insurance Agencies. You are receiving this
+          because you requested the playbook at renewalengineai.com.
+        </p>
       </div>
     `,
   });


### PR DESCRIPTION
Codebase-specific growth plan built on a full review of the marketing
funnel and product. Defines a two-path conversion architecture
(new self-serve SaaS trial + existing Calendly audit), a pillar/cluster
content model with an automated-engine upgrade path, a GEO program
(answer-first content, per-article FAQ schema, entity footprint,
original benchmark report, AI-referral measurement), and SCO = SEO + CRO.

Flags concrete leaks found in review: broken /api/lead-magnet route,
no self-serve signup, weak in-content CTAs, no AI-referral tracking.
Supersedes the stale pre-Next.js .html-era strategy docs.

https://claude.ai/code/session_01BjvvMHg4PYaBzBnGFHBJKS